### PR TITLE
Set default port to 5300 to avoid conflict with SwarmChat

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@
 using SquishySim.Services;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.WebHost.UseUrls("http://localhost:5300");
 
 builder.Services.AddSingleton<SimulationService>();
 builder.Services.AddControllers();


### PR DESCRIPTION
## What Changed

Added `builder.WebHost.UseUrls("http://localhost:5300")` to Program.cs so the API defaults to port 5300 without needing `--urls` flag on the command line. Port 5000 (ASP.NET default) conflicts with SwarmChat.

## How Tested

Verified `dotnet run --project SquishySim.Api.csproj` starts on 5300.

## Breaking Changes

None — this just changes the default port from 5000 to 5300.