### PR TITLE
Add social drive (Phase 2)

### DIFF
--- a/Actions/ActionCatalog.cs
+++ b/Actions/ActionCatalog.cs
@@ -39,6 +39,13 @@ public static class ActionCatalog
             Id = "do_nothing",
             Description = "sit and stare",
             Effect = new ActionEffect(HungerDelta:  0.00f, ThirstDelta:  0.00f, FatigueDelta: -0.03f, BladderDelta:  0.00f, MoodDelta: -0.04f)
+        },
+        new GameAction
+        {
+            Id = "socialize",
+            Description = "spend time with another agent",
+            // SocialDelta is applied by SimulationService (only if a partner is found)
+            Effect = new ActionEffect(HungerDelta: 0.00f, ThirstDelta: 0.00f, FatigueDelta: 0.00f, BladderDelta: 0.00f, MoodDelta: 0.00f, SocialDelta: -0.25f)
         }
     };
 

--- a/Actions/GameAction.cs
+++ b/Actions/GameAction.cs
@@ -5,7 +5,8 @@ public record ActionEffect(
     float ThirstDelta,
     float FatigueDelta,
     float BladderDelta,
-    float MoodDelta
+    float MoodDelta,
+    float SocialDelta = 0f
 );
 
 public class GameAction
@@ -25,6 +26,7 @@ public class GameAction
             if (Effect.FatigueDelta != 0) parts.Add($"fatigue {Effect.FatigueDelta:+0.0;-0.0}");
             if (Effect.BladderDelta != 0) parts.Add($"bladder {Effect.BladderDelta:+0.0;-0.0}");
             if (Effect.MoodDelta    != 0) parts.Add($"mood {Effect.MoodDelta:+0.0;-0.0}");
+            if (Effect.SocialDelta  != 0) parts.Add($"social {Effect.SocialDelta:+0.0;-0.0}");
             return string.Join(", ", parts);
         }
     }

--- a/Body/BodyState.cs
+++ b/Body/BodyState.cs
@@ -11,12 +11,14 @@ public class BodyState
     public float Thirst  { get; set; } = 0.10f;
     public float Fatigue { get; set; } = 0.10f;
     public float Bladder { get; set; } = 0.00f;
+    public float Social  { get; set; } = 0.10f;  // 0=satisfied, 1=isolated
     public float Mood    { get; set; } = 0.70f;
 
     public string HungerLabel  => DriveLabel(Hunger);
     public string ThirstLabel  => DriveLabel(Thirst);
     public string FatigueLabel => DriveLabel(Fatigue);
     public string BladderLabel => DriveLabel(Bladder);
+    public string SocialLabel  => DriveLabel(Social);
 
     public string MoodLabel => Mood switch
     {
@@ -40,6 +42,7 @@ public class BodyState
         Thirst  = Math.Clamp(Thirst,  0f, 1f);
         Fatigue = Math.Clamp(Fatigue, 0f, 1f);
         Bladder = Math.Clamp(Bladder, 0f, 1f);
+        Social  = Math.Clamp(Social,  0f, 1f);
         Mood    = Math.Clamp(Mood,    0f, 1f);
     }
 }

--- a/Body/DriveSystem.cs
+++ b/Body/DriveSystem.cs
@@ -10,7 +10,17 @@ public static class DriveSystem
     private const float ThirstRate  = 0.025f;  // critical in ~40 ticks
     private const float FatigueRate = 0.012f;  // critical in ~83 ticks
 
-    public static void Tick(BodyState state)
+    // Social drive constants
+    private const float SocialDecayRate    = 0.012f;  // isolation grows ~83 ticks to critical
+    private const float SatisfactionAmount = 0.25f;   // qualifying interaction reduces isolation
+    private const float MoodThreshold      = 0.70f;   // social isolation above this hurts mood
+    private const float MoodDistressCoeff  = 0.12f;
+
+    /// <param name="hadQualifyingInteraction">
+    /// True if this agent had a successful social interaction last tick (set by SimulationService).
+    /// Satisfies the social drive instead of applying decay — mutually exclusive per tick.
+    /// </param>
+    public static void Tick(BodyState state, bool hadQualifyingInteraction = false)
     {
         var modifiers = DriveInteractionSystem.ComputeCrossEffects(state);
 
@@ -18,12 +28,19 @@ public static class DriveSystem
         state.Thirst  += ThirstRate;
         state.Fatigue += FatigueRate * modifiers.FatigueRateMultiplier;
 
+        // Social drive: decay OR satisfaction each tick (mutually exclusive)
+        if (hadQualifyingInteraction)
+            state.Social -= SatisfactionAmount;
+        else
+            state.Social += SocialDecayRate;
+
         // Mood degrades when critical drives go unmet
         float distress = 0f;
         if (state.Hunger  > 0.70f) distress += (state.Hunger  - 0.70f) * 0.10f;
         if (state.Thirst  > 0.70f) distress += (state.Thirst  - 0.70f) * 0.15f;
         if (state.Fatigue > 0.80f) distress += (state.Fatigue - 0.80f) * 0.08f;
         if (state.Bladder > 0.80f) distress += (state.Bladder - 0.80f) * 0.20f;
+        if (state.Social >= MoodThreshold) distress += (state.Social - MoodThreshold) * MoodDistressCoeff;
 
         state.Mood -= distress;
 

--- a/Domain/Agent.cs
+++ b/Domain/Agent.cs
@@ -19,4 +19,8 @@ public class Agent
 
     public LlmConfig       LlmConfig     { get; set; } = new();
     public IDecisionMaker  DecisionMaker { get; set; } = new RuleBasedDecisionMaker();
+
+    // Set by SimulationService when a socialize action succeeds this tick;
+    // consumed by DriveSystem.Tick the following tick to apply social satisfaction.
+    public bool HadSocialInteractionLastTick { get; set; } = false;
 }

--- a/Mind/RuleBasedDecisionMaker.cs
+++ b/Mind/RuleBasedDecisionMaker.cs
@@ -27,6 +27,9 @@ public class RuleBasedDecisionMaker : IDecisionMaker
         if (state.Fatigue > 0.75f)
             return Done("sleep", "fatigue is high");
 
+        if (state.Social > 0.65f)
+            return Done("socialize", "feeling isolated");
+
         if (state.Mood < 0.35f)
             return Done("wander", "mood is low — needs stimulation");
 

--- a/Services/SimulationService.cs
+++ b/Services/SimulationService.cs
@@ -114,6 +114,7 @@ public class SimulationService
                 case "thirst":  agent.Drives.Thirst  = clamped; break;
                 case "fatigue": agent.Drives.Fatigue = clamped; break;
                 case "bladder": agent.Drives.Bladder = clamped; break;
+                case "social":  agent.Drives.Social  = clamped; break;
                 case "mood":    agent.Drives.Mood    = clamped; break;
                 default: return false;
             }
@@ -158,9 +159,17 @@ public class SimulationService
         _tickCount++;
         var now = DateTimeOffset.UtcNow;
 
+        // Collect which agents had a successful social interaction last tick,
+        // then reset the flags so this tick starts fresh.
+        var hadInteractionLastTick = _agents
+            .Where(a => a.HadSocialInteractionLastTick)
+            .Select(a => a.Id)
+            .ToHashSet();
+        foreach (var a in _agents) a.HadSocialInteractionLastTick = false;
+
         foreach (var agent in _agents)
         {
-            DriveSystem.Tick(agent.Drives);
+            DriveSystem.Tick(agent.Drives, hadInteractionLastTick.Contains(agent.Id));
 
             try
             {
@@ -172,17 +181,24 @@ public class SimulationService
                     .ChooseAsync(agent.Drives, ActionCatalog.All)
                     .GetAwaiter().GetResult();
 
-                agent.Drives.Hunger  += action.Effect.HungerDelta;
-                agent.Drives.Thirst  += action.Effect.ThirstDelta;
-                agent.Drives.Fatigue += action.Effect.FatigueDelta;
-                agent.Drives.Bladder += action.Effect.BladderDelta;
-                agent.Drives.Mood    += action.Effect.MoodDelta;
-                agent.Drives.Clamp();
+                if (action.Id == "socialize")
+                {
+                    ExecuteSocializeAction(agent, now, reason);
+                }
+                else
+                {
+                    agent.Drives.Hunger  += action.Effect.HungerDelta;
+                    agent.Drives.Thirst  += action.Effect.ThirstDelta;
+                    agent.Drives.Fatigue += action.Effect.FatigueDelta;
+                    agent.Drives.Bladder += action.Effect.BladderDelta;
+                    agent.Drives.Mood    += action.Effect.MoodDelta;
+                    agent.Drives.Clamp();
 
-                agent.CurrentAction = action.Id;
-                agent.CurrentReason = reason;
+                    agent.CurrentAction = action.Id;
+                    agent.CurrentReason = reason;
+                }
 
-                agent.Thoughts.Add(new ThoughtEntry(now, $"{action.Id}: {reason}"));
+                agent.Thoughts.Add(new ThoughtEntry(now, $"{agent.CurrentAction}: {agent.CurrentReason}"));
                 if (agent.Thoughts.Count > 200) agent.Thoughts.RemoveAt(0);
             }
             catch (Exception ex)
@@ -191,8 +207,40 @@ public class SimulationService
             }
         }
 
-        // PROTOTYPE: Simple inter-agent messaging — agents occasionally comment on state
+        // PROTOTYPE: Simple inter-agent messaging — agents occasionally comment on state.
+        // Background chatter does NOT satisfy the social drive (no HadSocialInteractionLastTick set).
         MaybeGenerateConversations(now);
+    }
+
+    private void ExecuteSocializeAction(Agent agent, DateTimeOffset now, string reason)
+    {
+        var partner = _agents
+            .Where(a => a.Id != agent.Id)
+            .OrderBy(_ => Guid.NewGuid())
+            .FirstOrDefault();
+
+        if (partner == null)
+        {
+            // No partner available — action fails, social drive unchanged this tick
+            agent.CurrentAction = "socialize";
+            agent.CurrentReason = $"{reason} (no partner available)";
+            return;
+        }
+
+        // Successful interaction — both agents receive social satisfaction next tick
+        agent.HadSocialInteractionLastTick   = true;
+        partner.HadSocialInteractionLastTick = true;
+
+        agent.CurrentAction = "socialize";
+        agent.CurrentReason = $"{reason} (with {partner.Name})";
+
+        var text = $"Hey {partner.Name}, wanted to catch up.";
+        var msg  = new ConversationMessage(now, agent.Id, partner.Id, text);
+        _allConversations.Add(msg);
+        agent.Messages.Add(msg);
+        partner.Messages.Add(msg);
+
+        if (_allConversations.Count > 500) _allConversations.RemoveAt(0);
     }
 
     private void MaybeGenerateConversations(DateTimeOffset now)

--- a/SquishySim.Tests/Body/DriveSystemSocialTests.cs
+++ b/SquishySim.Tests/Body/DriveSystemSocialTests.cs
@@ -1,0 +1,191 @@
+using SquishySim.Body;
+
+namespace SquishySim.Tests.Body;
+
+public class DriveSystemSocialTests
+{
+    // ── AC1: Social decay without interaction ────────────────────────────────
+
+    [Fact]
+    public void WhenNoQualifyingInteraction_SocialIncreasesBy_SocialDecayRate()
+    {
+        const float SocialDecayRate = 0.012f;
+        var state = new BodyState { Social = 0.20f };
+        var before = state.Social;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        Assert.Equal(SocialDecayRate, state.Social - before, precision: 6);
+    }
+
+    [Fact]
+    public void WhenNoQualifyingInteraction_SocialDefaultParam_SocialIncreases()
+    {
+        // Verify the default (no interaction) behavior without passing the param
+        const float SocialDecayRate = 0.012f;
+        var state = new BodyState { Social = 0.20f };
+        var before = state.Social;
+
+        DriveSystem.Tick(state);
+
+        Assert.Equal(SocialDecayRate, state.Social - before, precision: 6);
+    }
+
+    // ── AC2: Social satisfaction on qualifying interaction ───────────────────
+
+    [Fact]
+    public void WhenHadQualifyingInteraction_SocialDecreasesBySatisfactionAmount()
+    {
+        const float SatisfactionAmount = 0.25f;
+        var state = new BodyState { Social = 0.70f };
+        var before = state.Social;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: true);
+
+        Assert.Equal(SatisfactionAmount, before - state.Social, precision: 6);
+    }
+
+    // ── AC3: Mutual exclusivity — decay and satisfaction don't both apply ────
+
+    [Fact]
+    public void WhenHadQualifyingInteraction_SocialDecayDoesNotAlsoApply()
+    {
+        const float SocialDecayRate    = 0.012f;
+        const float SatisfactionAmount = 0.25f;
+        var state = new BodyState { Social = 0.70f };
+        var before = state.Social;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: true);
+
+        var delta = state.Social - before;
+        // Only satisfaction applied (negative), not decay (positive) — net is -(0.25f)
+        Assert.Equal(-SatisfactionAmount, delta, precision: 6);
+        Assert.NotEqual(-SatisfactionAmount + SocialDecayRate, delta, precision: 6);
+    }
+
+    [Fact]
+    public void WhenNoQualifyingInteraction_SatisfactionDoesNotAlsoApply()
+    {
+        const float SocialDecayRate = 0.012f;
+        var state = new BodyState { Social = 0.20f };
+        var before = state.Social;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        // Only decay applied (positive), not satisfaction (negative)
+        Assert.Equal(SocialDecayRate, state.Social - before, precision: 6);
+    }
+
+    // ── AC4: Social trigger threshold ────────────────────────────────────────
+
+    [Fact]
+    public void WhenSocialAboveTrigger_SocialIsAtUrgentOrHigherLabel()
+    {
+        // Trigger is at Social > 0.65f — verify state labels reflect this
+        var state = new BodyState { Social = 0.70f };
+        Assert.Equal("urgent", state.SocialLabel);
+    }
+
+    [Fact]
+    public void WhenSocialBelowTrigger_SocialLabelIsModerateOrLow()
+    {
+        var state = new BodyState { Social = 0.50f };
+        Assert.Equal("moderate", state.SocialLabel);
+    }
+
+    // ── AC5: Mood distress from social isolation ─────────────────────────────
+
+    [Fact]
+    public void WhenSocialAtOrAboveMoodThreshold_MoodDecreases()
+    {
+        const float MoodThreshold = 0.70f;
+        var state = new BodyState { Social = MoodThreshold, Mood = 0.80f };
+        var moodBefore = state.Mood;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        Assert.True(state.Mood < moodBefore,
+            $"Expected mood to decrease from {moodBefore} but got {state.Mood}");
+    }
+
+    [Fact]
+    public void WhenSocialBelowMoodThreshold_MoodNotAffectedBySocialDrive()
+    {
+        // Social = 0.50f, no other drives elevated — mood should be unchanged by social cross-effect
+        var state = new BodyState
+        {
+            Social  = 0.50f,
+            Mood    = 0.80f,
+            Hunger  = 0.10f,
+            Thirst  = 0.10f,
+            Fatigue = 0.10f,
+            Bladder = 0.10f
+        };
+        var moodBefore = state.Mood;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        Assert.Equal(moodBefore, state.Mood, precision: 6);
+    }
+
+    [Fact]
+    public void WhenSocialBelowThresholdEvenAfterDecay_MoodIsUnchanged()
+    {
+        // Social = 0.68f. After decay (+0.012f) = 0.692f — still below 0.70f threshold.
+        // No social distress should apply.
+        var state = new BodyState
+        {
+            Social  = 0.68f,
+            Mood    = 0.80f,
+            Hunger  = 0.10f,
+            Thirst  = 0.10f,
+            Fatigue = 0.10f,
+            Bladder = 0.10f
+        };
+        var moodBefore = state.Mood;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        Assert.Equal(moodBefore, state.Mood, precision: 6);
+    }
+
+    [Fact]
+    public void WhenSocialAt0_80_MoodDistressMatchesFormula()
+    {
+        // Within Tick: decay runs first (+0.012f), then distress is computed.
+        // Social after decay = 0.80f + 0.012f = 0.812f
+        // distress = (0.812f - 0.70f) * 0.12f = 0.01344f
+        const float SocialDecayRate   = 0.012f;
+        const float MoodThreshold     = 0.70f;
+        const float MoodDistressCoeff = 0.12f;
+        const float StartingSocial    = 0.80f;
+        float expectedDistress = (StartingSocial + SocialDecayRate - MoodThreshold) * MoodDistressCoeff;
+
+        var state = new BodyState
+        {
+            Social  = StartingSocial,
+            Mood    = 0.80f,
+            Hunger  = 0.10f,
+            Thirst  = 0.10f,
+            Fatigue = 0.10f,
+            Bladder = 0.10f
+        };
+        var moodBefore = state.Mood;
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: false);
+
+        Assert.Equal(expectedDistress, moodBefore - state.Mood, precision: 6);
+    }
+
+    // ── AC boundary: Social clamps to 0 after large satisfaction ────────────
+
+    [Fact]
+    public void WhenSocialLowAndHadInteraction_SocialClampsToZero()
+    {
+        var state = new BodyState { Social = 0.10f };  // 0.10f - 0.25f satisfaction = -0.15f → clamped to 0
+
+        DriveSystem.Tick(state, hadQualifyingInteraction: true);
+
+        Assert.Equal(0f, state.Social);
+    }
+}

--- a/SquishySim.Tests/Services/SimulationServiceSocialTests.cs
+++ b/SquishySim.Tests/Services/SimulationServiceSocialTests.cs
@@ -1,0 +1,154 @@
+using SquishySim.Services;
+
+namespace SquishySim.Tests.Services;
+
+/// <summary>
+/// Integration tests for social drive behavior in SimulationService.
+/// AC7: Socialize action succeeds when partner is available.
+/// AC8: Socialize action fails gracefully when no partner available.
+/// Note: SimulationService always seeds 3 agents (alice, bob, charlie),
+/// so there is always a partner available in the normal case.
+/// </summary>
+public class SimulationServiceSocialTests
+{
+    // ── AC7: Partner found — conversation generated, satisfaction next tick ──
+
+    [Fact]
+    public void WhenAgentSocializesWith_PartnerAvailable_ConversationIsGenerated()
+    {
+        var sim = new SimulationService();
+
+        // Set Alice's social drive above the trigger threshold
+        sim.SetDrive("alice", "social", 0.80);
+        // Set other drives low so Alice will choose socialize
+        sim.SetDrive("alice", "hunger",  0.10);
+        sim.SetDrive("alice", "thirst",  0.10);
+        sim.SetDrive("alice", "fatigue", 0.10);
+        sim.SetDrive("alice", "bladder", 0.10);
+
+        sim.Step();
+
+        var conversations = sim.AllConversations;
+        Assert.NotEmpty(conversations);
+        Assert.Contains(conversations, c => c.FromAgentId == "alice");
+    }
+
+    [Fact]
+    public void WhenSocializeSucceeds_AgentCurrentActionIs_Socialize()
+    {
+        var sim = new SimulationService();
+
+        sim.SetDrive("alice", "social", 0.80);
+        sim.SetDrive("alice", "hunger",  0.10);
+        sim.SetDrive("alice", "thirst",  0.10);
+        sim.SetDrive("alice", "fatigue", 0.10);
+        sim.SetDrive("alice", "bladder", 0.10);
+
+        sim.Step();
+
+        var alice = sim.GetAgent("alice")!;
+        Assert.Equal("socialize", alice.CurrentAction);
+    }
+
+    [Fact]
+    public void WhenSocializeSucceeds_SocialDriveDecreasesOnFollowingTick()
+    {
+        var sim = new SimulationService();
+
+        // Put Alice in isolation — above trigger
+        sim.SetDrive("alice", "social",  0.80);
+        sim.SetDrive("alice", "hunger",  0.10);
+        sim.SetDrive("alice", "thirst",  0.10);
+        sim.SetDrive("alice", "fatigue", 0.10);
+        sim.SetDrive("alice", "bladder", 0.10);
+
+        // Tick 1: Alice socializes — partner found, HadSocialInteractionLastTick set
+        sim.Step();
+        var socialAfterTick1 = sim.GetAgent("alice")!.Drives.Social;
+
+        // Tick 2: DriveSystem sees hadQualifyingInteraction=true — applies satisfaction (-0.25f)
+        sim.Step();
+        var socialAfterTick2 = sim.GetAgent("alice")!.Drives.Social;
+
+        Assert.True(socialAfterTick2 < socialAfterTick1,
+            $"Expected social to decrease after satisfaction tick. " +
+            $"Tick1={socialAfterTick1:F4}, Tick2={socialAfterTick2:F4}");
+    }
+
+    [Fact]
+    public void WhenSocializeSucceeds_PartnerAlsoReceivesSocialSatisfactionNextTick()
+    {
+        var sim = new SimulationService();
+
+        // Alice socializes; partner (bob or charlie) should also benefit
+        sim.SetDrive("alice", "social",  0.80);
+        sim.SetDrive("alice", "hunger",  0.10);
+        sim.SetDrive("alice", "thirst",  0.10);
+        sim.SetDrive("alice", "fatigue", 0.10);
+        sim.SetDrive("alice", "bladder", 0.10);
+
+        sim.Step();
+
+        // Find who alice talked to
+        var conversation = sim.AllConversations.FirstOrDefault(c => c.FromAgentId == "alice");
+        Assert.NotNull(conversation);
+        var partnerId = conversation.ToAgentId;
+
+        // Freeze partner's other drives so we can observe social change
+        sim.SetDrive(partnerId, "hunger",  0.10);
+        sim.SetDrive(partnerId, "thirst",  0.10);
+        sim.SetDrive(partnerId, "fatigue", 0.10);
+        sim.SetDrive(partnerId, "bladder", 0.10);
+
+        var partnerSocialAfterTick1 = sim.GetAgent(partnerId)!.Drives.Social;
+
+        sim.Step();  // Tick 2: partner gets satisfaction
+
+        var partnerSocialAfterTick2 = sim.GetAgent(partnerId)!.Drives.Social;
+        Assert.True(partnerSocialAfterTick2 < partnerSocialAfterTick1,
+            $"Expected partner {partnerId} social to decrease after satisfaction. " +
+            $"Tick1={partnerSocialAfterTick1:F4}, Tick2={partnerSocialAfterTick2:F4}");
+    }
+
+    // ── AC6: Background chatter does NOT satisfy social drive ───────────────
+
+    [Fact]
+    public void BackgroundChatterDoesNotSatisfySocialDrive()
+    {
+        // Background chatter fires every 5 ticks via MaybeGenerateConversations.
+        // It must not set HadSocialInteractionLastTick, so social drive keeps decaying.
+        var sim = new SimulationService();
+
+        // Keep social below the socialize trigger so only background chatter can fire
+        sim.SetDrive("alice", "social",  0.40);
+        sim.SetDrive("alice", "hunger",  0.10);
+        sim.SetDrive("alice", "thirst",  0.10);
+        sim.SetDrive("alice", "fatigue", 0.10);
+        sim.SetDrive("alice", "bladder", 0.10);
+
+        var socialBefore = sim.GetAgent("alice")!.Drives.Social;
+
+        // Run 5 ticks to guarantee background chatter fires
+        for (int i = 0; i < 5; i++) sim.Step();
+
+        var socialAfter = sim.GetAgent("alice")!.Drives.Social;
+
+        // Social should have increased (decay applied), not decreased (satisfaction)
+        Assert.True(socialAfter > socialBefore,
+            $"Expected social to increase via decay (no qualifying interaction). " +
+            $"Before={socialBefore:F4}, After={socialAfter:F4}");
+    }
+
+    // ── Verify SetDrive accepts "social" ─────────────────────────────────────
+
+    [Fact]
+    public void WhenSetDriveCalledWithSocial_DriveValueIsUpdated()
+    {
+        var sim = new SimulationService();
+
+        var result = sim.SetDrive("alice", "social", 0.75);
+
+        Assert.True(result);
+        Assert.Equal(0.75f, sim.GetAgent("alice")!.Drives.Social, precision: 4);
+    }
+}


### PR DESCRIPTION
## Summary

- **`BodyState.Social`** — new float drive (0=satisfied, 1=isolated) with `SocialLabel`
- **`DriveSystem.Tick(state, hadQualifyingInteraction = false)`** — social decays each tick OR satisfaction (-0.25f) applied if agent had a qualifying interaction last tick (mutually exclusive per AC3); `Social >= 0.70f` applies mood distress (coeff 0.12f)
- **`ActionEffect.SocialDelta`** — added with default 0f (backward-compatible with all existing action definitions)
- **`ActionCatalog`** — new `"socialize"` action (SocialDelta -0.25f)
- **`RuleBasedDecisionMaker`** — triggers `"socialize"` when `Social > 0.65f`
- **`Agent.HadSocialInteractionLastTick`** — one-tick-lag flag: set when socialize succeeds, consumed by DriveSystem.Tick next tick
- **`SimulationService`** — `ExecuteSocializeAction`: finds random partner → sets flag on both → generates conversation. No partner → action fails, no delta. Background chatter (`MaybeGenerateConversations`) does NOT satisfy social drive. Added `"social"` to `SetDrive`.

## Design note: one-tick lag

Social satisfaction is applied the tick *after* a successful socialize action (via `hadQualifyingInteraction`). This keeps DriveSystem.Tick pure and injectable for testing without restructuring the action-choice loop. The lag is imperceptible at the prototype scale.

## How it was tested

- `dotnet test` — 29/29 pass
- **DriveSystemSocialTests** (11 tests): AC1 decay, AC2 satisfaction, AC3 mutex, AC4 label threshold, AC5 mood distress formula, boundary clamp
- **SimulationServiceSocialTests** (6 tests): AC7 partner-found integration (conversation generated, agent action = "socialize", social decreases next tick, partner also benefits), AC6 background chatter doesn't satisfy, SetDrive accepts "social"

Implements SquishySim Phase 2 per spec locked in 0xB17 + Quinn AC (0xB1C).

Reviewers: @architect @qa_tester