### PR TITLE
Expose social drive in API response and web UI

### DIFF
--- a/Controllers/AgentsController.cs
+++ b/Controllers/AgentsController.cs
@@ -28,7 +28,7 @@ public class AgentsController : ControllerBase
     [HttpPost("{id}/drives/{drive}")]
     public IActionResult SetDrive(string id, string drive, [FromBody] SetDriveRequest req)
     {
-        var valid = new[] { "hunger", "thirst", "fatigue", "bladder", "mood" };
+        var valid = new[] { "hunger", "thirst", "fatigue", "bladder", "social", "mood" };
         if (!valid.Contains(drive.ToLowerInvariant()))
             return BadRequest(new { error = $"Unknown drive '{drive}'. Valid: {string.Join(", ", valid)}" });
 
@@ -91,11 +91,11 @@ public record AgentDto(
 {
     public static AgentDto From(SquishySim.Domain.Agent a) => new(
         a.Id, a.Name,
-        new DrivesDto(a.Drives.Hunger, a.Drives.Thirst, a.Drives.Fatigue, a.Drives.Bladder, a.Drives.Mood),
+        new DrivesDto(a.Drives.Hunger, a.Drives.Thirst, a.Drives.Fatigue, a.Drives.Bladder, a.Drives.Social, a.Drives.Mood),
         a.CurrentAction, a.CurrentReason,
         new LlmConfigDto(a.LlmConfig.Model, a.LlmConfig.BaseUrl, a.LlmConfig.HasApiKey ? "***" : null)
     );
 }
 
-public record DrivesDto(float Hunger, float Thirst, float Fatigue, float Bladder, float Mood);
+public record DrivesDto(float Hunger, float Thirst, float Fatigue, float Bladder, float Social, float Mood);
 public record LlmConfigDto(string Model, string BaseUrl, string? ApiKey);

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -1,8 +1,8 @@
 // PROTOTYPE: SquishySim web client
 'use strict';
 
-const DRIVES = ['hunger', 'thirst', 'fatigue', 'bladder', 'mood'];
-const DEFAULT_DRIVES = { hunger: 0.10, thirst: 0.10, fatigue: 0.10, bladder: 0.00, mood: 0.70 };
+const DRIVES = ['hunger', 'thirst', 'fatigue', 'bladder', 'social', 'mood'];
+const DEFAULT_DRIVES = { hunger: 0.10, thirst: 0.10, fatigue: 0.10, bladder: 0.00, social: 0.10, mood: 0.70 };
 
 let selectedAgentId = null;
 let showingConversations = false;


### PR DESCRIPTION
## Summary

Three gaps from PR #7 (social drive) that prevented it from showing in the UI:

- **`DrivesDto`** was missing `Social` — API `/agents` response silently dropped the field
- **`AgentsController` drive whitelist** excluded `"social"` — `POST /agents/{id}/drives/social` returned HTTP 400
- **`app.js` `DRIVES` / `DEFAULT_DRIVES`** arrays were hardcoded to the original 5 drives — social row never rendered

## How it was tested

- Built successfully, 29/29 tests pass
- Social drive row now renders in the UI with bar + slider
- `POST /agents/alice/drives/social` with `{"value": 0.8}` returns 200 (was 400 before)
- Reset drives button now resets social to 0.10

Reviewers: @architect @qa_tester