### PR TITLE
Add auto-versioning via git commit count

### DIFF
--- a/Controllers/SimController.cs
+++ b/Controllers/SimController.cs
@@ -1,4 +1,5 @@
 // PROTOTYPE: Simulation control REST API
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using SquishySim.Services;
 
@@ -48,8 +49,13 @@ public class SimController : ControllerBase
 
     // GET /sim/status  — convenience for UI polling
     [HttpGet("status")]
-    public IActionResult Status() =>
-        Ok(new { paused = _sim.IsPaused, tick = _sim.TickCount, speed = _sim.SpeedMultiplier });
+    public IActionResult Status()
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "unknown";
+        return Ok(new { paused = _sim.IsPaused, tick = _sim.TickCount, speed = _sim.SpeedMultiplier, version });
+    }
 }
 
 public record SetSpeedRequest(double Multiplier);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <Target Name="SetVersionFromGit" BeforeTargets="GenerateAssemblyInfo">
+    <!-- Run git rev-list to get total commit count for patch version -->
+    <Exec Command="git rev-list --count HEAD"
+          ConsoleToMSBuild="true"
+          ContinueOnError="true"
+          IgnoreExitCode="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCommitCount" />
+    </Exec>
+    <PropertyGroup>
+      <!-- Fall back to 0 if git is unavailable (e.g. CI without git, shallow clone) -->
+      <GitCommitCount Condition="'$(GitCommitCount)' == ''">0</GitCommitCount>
+      <GitCommitCount>$(GitCommitCount.Trim())</GitCommitCount>
+      <Version>0.1.$(GitCommitCount)</Version>
+      <InformationalVersion>v0.1.$(GitCommitCount)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,12 @@
 // PROTOTYPE: SquishySim REST API + web UI — not production ready
+using System.Reflection;
 using SquishySim.Services;
+
+var version = Assembly.GetExecutingAssembly()
+    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+    ?.InformationalVersion ?? "unknown";
+
+Console.WriteLine($"SquishySim {version} starting on http://localhost:5300");
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.UseUrls("http://localhost:5300");

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -43,6 +43,7 @@ async function refresh() {
     ]);
 
     document.getElementById('tick-display').textContent = `Tick ${statusData.tick}`;
+    document.getElementById('version-display').textContent = statusData.version ?? '';
 
     const isPaused = statusData.paused;
     document.getElementById('btn-pause').classList.toggle('active', isPaused === true);

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="header">
     <span id="title">SquishySim</span>
+    <span id="version-display"></span>
     <span id="sim-controls">
       <span id="tick-display">Tick 0</span>
       <button id="btn-step">Step</button>


### PR DESCRIPTION
## Summary

- **`Directory.Build.props`** (new) — MSBuild `Exec` runs `git rev-list --count HEAD` at build time; bakes `Version=0.1.{count}` and `InformationalVersion=v0.1.{count}` into the assembly. Falls back to `0` if git is unavailable (shallow clones, CI without git). Uses `BeforeTargets="GenerateAssemblyInfo"` to run before assembly attributes are generated.
- **`Program.cs`** — logs version at server startup: `SquishySim v0.1.N starting on http://localhost:5300`
- **`SimController GET /sim/status`** — adds `version` field to the response (alongside `paused`, `tick`, `speed`)
- **`wwwroot/index.html`** — adds `#version-display` span in header next to title
- **`wwwroot/app.js`** — populates `#version-display` from `statusData.version` on each refresh cycle

Pattern follows Adrian's REQ-013 approach in SwarmChat (assembly reflection via `AssemblyInformationalVersionAttribute`).

## How it was tested

- Built successfully — `8` printed to console during build (git commit count), version baked as `v0.1.8`
- 29/29 tests pass
- Startup banner: `SquishySim v0.1.8 starting on http://localhost:5300`

Reviewers: @architect @qa_tester