### PR TITLE
Display thought log and conversations side by side

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -59,14 +59,16 @@
           <button id="btn-save-llm">Save</button>
         </div>
 
-        <div id="thoughts-section">
-          <h3>Thought Log</h3>
-          <div id="thought-log"></div>
-        </div>
+        <div id="thoughts-messages-row">
+          <div id="thoughts-section">
+            <h3>Thought Log</h3>
+            <div id="thought-log"></div>
+          </div>
 
-        <div id="messages-section">
-          <h3>Conversations (this agent)</h3>
-          <div id="agent-messages"></div>
+          <div id="messages-section">
+            <h3>Conversations (this agent)</h3>
+            <div id="agent-messages"></div>
+          </div>
         </div>
       </div>
 

--- a/wwwroot/styles.css
+++ b/wwwroot/styles.css
@@ -53,7 +53,15 @@ h3 { color: #9cdcfe; font-size: 0.85em; text-transform: uppercase; letter-spacin
 #llm-section input { background: #3e3e42; border: 1px solid #555; color: #d4d4d4; padding: 3px 6px; font-family: monospace; font-size: 0.85em; width: 240px; margin-left: 6px; }
 #btn-save-llm { margin-top: 6px; background: #094771; border: 1px solid #4ec9b0; color: #4ec9b0; padding: 3px 12px; cursor: pointer; border-radius: 3px; font-family: monospace; font-size: 0.8em; }
 
-/* Thought log / messages */
+/* Thought log / messages — side-by-side layout */
+#thoughts-messages-row {
+  display: flex;
+  gap: 1rem;
+}
+#thoughts-messages-row > div {
+  flex: 1;
+  min-width: 0; /* prevent flex children from overflowing their scrollable containers */
+}
 #thought-log, #agent-messages, #global-feed {
   background: #252526; border: 1px solid #3e3e42; border-radius: 3px;
   padding: 8px; max-height: 220px; overflow-y: auto; font-size: 0.8em;


### PR DESCRIPTION
## Summary

Wraps `#thoughts-section` and `#messages-section` in a new `#thoughts-messages-row` div with `display: flex`, so they sit side by side at ~50% each instead of stacked vertically.

**HTML:** one new wrapper div around the two existing sections.

**CSS:**
```css
#thoughts-messages-row { display: flex; gap: 1rem; }
#thoughts-messages-row > div { flex: 1; min-width: 0; }
```
`min-width: 0` prevents the scrollable log containers from overflowing their flex cell.

No changes to `#agent-detail` or any other sections — flex applied only to the wrapper, per Adrian's note.

## How it was tested

- Built successfully, 29/29 tests pass
- Loaded the UI — thought log and conversations panels appear side by side, each ~50% width, independently scrollable

Reviewers: @architect @qa_tester