### PR TITLE
Add Phase 3 context modifier — social engagement raises action thresholds

### DIFF
--- a/Controllers/AgentsController.cs
+++ b/Controllers/AgentsController.cs
@@ -87,13 +87,15 @@ public record AgentDto(
     string Id, string Name,
     DrivesDto Drives,
     string CurrentAction, string CurrentReason,
-    LlmConfigDto LlmConfig)
+    LlmConfigDto LlmConfig,
+    bool ContextModifierActive)
 {
     public static AgentDto From(SquishySim.Domain.Agent a) => new(
         a.Id, a.Name,
         new DrivesDto(a.Drives.Hunger, a.Drives.Thirst, a.Drives.Fatigue, a.Drives.Bladder, a.Drives.Social, a.Drives.Mood),
         a.CurrentAction, a.CurrentReason,
-        new LlmConfigDto(a.LlmConfig.Model, a.LlmConfig.BaseUrl, a.LlmConfig.HasApiKey ? "***" : null)
+        new LlmConfigDto(a.LlmConfig.Model, a.LlmConfig.BaseUrl, a.LlmConfig.HasApiKey ? "***" : null),
+        a.Drives.Social < 0.65f
     );
 }
 

--- a/Mind/RuleBasedDecisionMaker.cs
+++ b/Mind/RuleBasedDecisionMaker.cs
@@ -12,22 +12,29 @@ public class RuleBasedDecisionMaker : IDecisionMaker
 {
     public string DisplayName => "rule-based";
 
+    // Context modifier: when Social < SocialTriggerThreshold, agent is socially engaged —
+    // physical-drive action thresholds are raised by ContextModifier (capped at 1.0).
+    private const float ContextModifier       = 0.20f;
+    private const float SocialTriggerThreshold = 0.65f;
+
     public Task<(GameAction action, string reason)> ChooseAsync(
         BodyState state, IReadOnlyList<GameAction> actions)
     {
-        if (state.Bladder > 0.80f)
+        float mod = state.Social < SocialTriggerThreshold ? ContextModifier : 0f;
+
+        if (state.Bladder > Math.Min(0.80f + mod, 1.0f))
             return Done("use_toilet", "bladder is urgent");
 
-        if (state.Thirst > 0.70f)
+        if (state.Thirst > Math.Min(0.70f + mod, 1.0f))
             return Done("drink_water", "thirst is high");
 
-        if (state.Hunger > 0.70f)
+        if (state.Hunger > Math.Min(0.70f + mod, 1.0f))
             return Done("eat_food", "hunger is high");
 
-        if (state.Fatigue > 0.75f)
+        if (state.Fatigue > Math.Min(0.75f + mod, 1.0f))
             return Done("sleep", "fatigue is high");
 
-        if (state.Social > 0.65f)
+        if (state.Social > SocialTriggerThreshold)
             return Done("socialize", "feeling isolated");
 
         if (state.Mood < 0.35f)

--- a/SquishySim.Tests/Mind/RuleBasedDecisionMakerPhase3Tests.cs
+++ b/SquishySim.Tests/Mind/RuleBasedDecisionMakerPhase3Tests.cs
@@ -1,0 +1,131 @@
+using SquishySim.Actions;
+using SquishySim.Body;
+using SquishySim.Mind;
+
+namespace SquishySim.Tests.Mind;
+
+public class RuleBasedDecisionMakerPhase3Tests
+{
+    private static readonly RuleBasedDecisionMaker _maker = new();
+    private static readonly IReadOnlyList<GameAction> _actions = ActionCatalog.All;
+
+    private static async Task<string> Choose(BodyState state)
+    {
+        var (action, _) = await _maker.ChooseAsync(state, _actions);
+        return action.Id;
+    }
+
+    // ── AC1: Modifier active when Social < 0.65f ─────────────────────────────
+
+    [Fact]
+    public async Task WhenSocialBelow0_65_EffectiveHungerThresholdRaisedTo0_90()
+    {
+        // Social = 0.50f → modifier active → effective hunger = min(0.70 + 0.20, 1.0) = 0.90
+        // 0.90 is NOT > 0.90 (strict) → hunger action does not fire
+        var state = new BodyState { Social = 0.50f, Hunger = 0.90f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task WhenSocialBelow0_65_HungerAt0_91_ActionFires()
+    {
+        // 0.91 > 0.90 (effective threshold) → hunger action fires
+        var state = new BodyState { Social = 0.50f, Hunger = 0.91f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    // ── AC2: Modifier inactive when Social >= 0.65f ──────────────────────────
+
+    [Fact]
+    public async Task WhenSocialAt0_65_ModifierInactive_BaseThresholdApplies()
+    {
+        // Social = 0.65f → condition is strict <, so modifier is OFF → base hunger = 0.70f
+        // 0.71 > 0.70 → hunger action fires
+        var state = new BodyState { Social = 0.65f, Hunger = 0.71f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    // ── AC3: Boundary — Social 0.64f vs 0.65f ────────────────────────────────
+
+    [Fact]
+    public async Task WhenSocialAt0_64_EffectiveHungerIs0_90_HungerAt0_85_DoesNotFire()
+    {
+        // Social = 0.64f → modifier active → effective = 0.90f; 0.85 not > 0.90
+        var state = new BodyState { Social = 0.64f, Hunger = 0.85f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task WhenSocialAt0_65_BaseHungerThreshold_HungerAt0_75_Fires()
+    {
+        // Social = 0.65f → modifier inactive → base = 0.70f; 0.75 > 0.70
+        var state = new BodyState { Social = 0.65f, Hunger = 0.75f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    // ── AC4: Bladder cap — Math.Min(0.80 + 0.20, 1.0) = 1.00 ───────────────
+
+    [Fact]
+    public async Task WhenSocialBelow0_65_EffectiveBladderThresholdCappedAt1_00()
+    {
+        // Effective = min(0.80 + 0.20, 1.0) = 1.00; 1.00 not > 1.00 (strict)
+        var state = new BodyState { Social = 0.50f, Bladder = 1.00f };
+
+        Assert.NotEqual("use_toilet", await Choose(state));
+    }
+
+    [Fact]
+    public async Task WhenSocialAt0_65_ModifierInactive_BladderAt0_81_Fires()
+    {
+        // Modifier inactive → base = 0.80f; 0.81 > 0.80
+        var state = new BodyState { Social = 0.65f, Bladder = 0.81f };
+
+        Assert.Equal("use_toilet", await Choose(state));
+    }
+
+    // ── Modifier applies to all four physical drives ─────────────────────────
+
+    [Fact]
+    public async Task WhenModifierActive_ThirstAt0_85_DoesNotFire()
+    {
+        // Effective thirst = min(0.70 + 0.20, 1.0) = 0.90; 0.85 not > 0.90
+        var state = new BodyState { Social = 0.50f, Thirst = 0.85f };
+
+        Assert.NotEqual("drink_water", await Choose(state));
+    }
+
+    [Fact]
+    public async Task WhenModifierActive_FatigueAt0_90_DoesNotFire()
+    {
+        // Effective fatigue = min(0.75 + 0.20, 1.0) = 0.95; 0.90 not > 0.95
+        var state = new BodyState { Social = 0.50f, Fatigue = 0.90f };
+
+        Assert.NotEqual("sleep", await Choose(state));
+    }
+
+    [Fact]
+    public async Task WhenModifierActive_FatigueAt0_96_Fires()
+    {
+        // 0.96 > 0.95 (effective fatigue threshold)
+        var state = new BodyState { Social = 0.50f, Fatigue = 0.96f };
+
+        Assert.Equal("sleep", await Choose(state));
+    }
+
+    // ── Mood and Social thresholds are NOT modified ───────────────────────────
+
+    [Fact]
+    public async Task WhenModifierActive_SocialThresholdUnchanged_SocializeStillFires()
+    {
+        // Social > 0.65f → socialize fires regardless of modifier (modifier requires Social < 0.65f,
+        // so this state has modifier inactive anyway — confirms socialize threshold not shifted)
+        var state = new BodyState { Social = 0.70f };
+
+        Assert.Equal("socialize", await Choose(state));
+    }
+}


### PR DESCRIPTION
## Summary

- **`Mind/RuleBasedDecisionMaker.cs`** — context modifier derived from `state.Social < 0.65f`. When active, physical-drive thresholds raised by `ContextModifier = 0.20f` via `Math.Min(base + 0.20f, 1.0f)`. Hunger (0.70→0.90), thirst (0.70→0.90), fatigue (0.75→0.95), bladder (0.80→1.00 capped). Mood and Social thresholds unchanged.
- **`Controllers/AgentsController.cs`** — `AgentDto` now includes `contextModifierActive` (bool: `Social < 0.65f`), satisfying AC5.
- **`SquishySim.Tests/Mind/RuleBasedDecisionMakerPhase3Tests.cs`** — 11 new unit tests, all pure `RuleBasedDecisionMaker` + `BodyState` (no service layer needed).

No new Agent fields. No interface changes. `IDecisionMaker.ChooseAsync` signature unchanged — `RuleBasedDecisionMaker` reads `state.Social` directly.

## Verification

- 40/40 tests pass (29 existing + 11 new)
- AC1: Social=0.50, Hunger=0.90 → not eat (0.90 not > 0.90); Hunger=0.91 → eat
- AC2: Social=0.65, Hunger=0.71 → eat (modifier OFF, base 0.70f)
- AC3: Social=0.64 boundary confirmed; Social=0.65 fires at base threshold
- AC4: Social=0.50, Bladder=1.00 → no relief (strict >); modifier off, Bladder=0.81 → fires
- All four physical drives covered; fatigue effective 0.95f verified

Reviewers: @architect @qa_tester