### PR TITLE
Add hover tooltips to SVG map agent circles and resource icons

### DIFF
--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -305,14 +305,15 @@ function renderSimMap(agents) {
         const circleAttrs = { cx: a.position.x, cy: a.position.y, r, fill: color };
         if (isSelected) { circleAttrs.stroke = '#ffffff'; circleAttrs['stroke-width'] = '0.15'; }
         const circle = svgEl('circle', circleAttrs);
+        let tip = null;
         if (a.drives) {
             const d = a.drives;
-            const tip = `${a.name}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}`;
+            tip = `${a.name}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}`;
             circle.appendChild(svgTitle(tip));
         }
         mapDynamic.appendChild(circle);
 
-        // Initial of agent name as label
+        // Initial of agent name as label — also carries tooltip so hovering the letter works
         const label = a.name ? a.name[0] : a.id[0].toUpperCase();
         const t = svgEl('text', {
             x: a.position.x, y: a.position.y,
@@ -320,6 +321,7 @@ function renderSimMap(agents) {
             'text-anchor': 'middle', 'dominant-baseline': 'central',
         });
         t.textContent = label;
+        if (tip) t.appendChild(svgTitle(tip));
         mapDynamic.appendChild(t);
     });
 }


### PR DESCRIPTION
## Summary

- **Agent circles**: hovering shows name, all 6 drive values (2dp), and current nav state
- **Resource icons**: hovering shows full resource name (Food, Water, Latrine, Shelter)
- Uses native SVG `<title>` element — browser renders as a tooltip on hover, no custom div needed
- Added `svgTitle(text)` helper to keep tooltip creation clean
- Added `name` field to `RESOURCES` constant for the full resource name

## Test plan

- [ ] Run `dotnet run --project SquishySim.Api.csproj` (port 5300)
- [ ] Hover over an agent circle — tooltip shows name, drives, nav state
- [ ] Hover over a resource icon — tooltip shows full name (e.g. "Food", not "F")
- [ ] Verify tooltip updates each poll (dynamic layer is rebuilt each tick)

Prototype tier — manual verification only. Closes #17.

Branches from `feature/map-ui` (PR #14); will rebase to main once #14 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)