### PR TITLE
Add Phase 4 suppression budget — gate on context modifier layer

### DIFF
--- a/Body/BodyState.cs
+++ b/Body/BodyState.cs
@@ -14,6 +14,9 @@ public class BodyState
     public float Social  { get; set; } = 0.10f;  // 0=satisfied, 1=isolated
     public float Mood    { get; set; } = 0.70f;
 
+    public float    SuppressionBudget { get; set; } = 1.0f;  // 1.0=full capacity, 0.0=depleted/snapped
+    public DateTime? SnappedAt        { get; set; }          // set on first snap, cleared on recovery above 0.25f
+
     public string HungerLabel  => DriveLabel(Hunger);
     public string ThirstLabel  => DriveLabel(Thirst);
     public string FatigueLabel => DriveLabel(Fatigue);
@@ -38,11 +41,12 @@ public class BodyState
 
     public void Clamp()
     {
-        Hunger  = Math.Clamp(Hunger,  0f, 1f);
-        Thirst  = Math.Clamp(Thirst,  0f, 1f);
-        Fatigue = Math.Clamp(Fatigue, 0f, 1f);
-        Bladder = Math.Clamp(Bladder, 0f, 1f);
-        Social  = Math.Clamp(Social,  0f, 1f);
-        Mood    = Math.Clamp(Mood,    0f, 1f);
+        Hunger            = Math.Clamp(Hunger,            0f, 1f);
+        Thirst            = Math.Clamp(Thirst,            0f, 1f);
+        Fatigue           = Math.Clamp(Fatigue,           0f, 1f);
+        Bladder           = Math.Clamp(Bladder,           0f, 1f);
+        Social            = Math.Clamp(Social,            0f, 1f);
+        Mood              = Math.Clamp(Mood,              0f, 1f);
+        SuppressionBudget = Math.Clamp(SuppressionBudget, 0f, 1f);
     }
 }

--- a/Body/DriveSystem.cs
+++ b/Body/DriveSystem.cs
@@ -16,6 +16,12 @@ public static class DriveSystem
     private const float MoodThreshold      = 0.70f;   // social isolation above this hurts mood
     private const float MoodDistressCoeff  = 0.12f;
 
+    // SuppressionBudget constants — tuned empirically after gate is in (Phase 4 calibration).
+    // Target: snaps under ~15–20 ticks of compound pressure, recovers in ~30–40 comfortable ticks.
+    private const float SnapDepletionFast = 0.05f;   // compound pressure (hunger+fatigue >= 0.70): ~20 ticks to deplete
+    private const float SnapDepletionSlow = 0.02f;   // single critical drive > 0.85f: ~50 ticks to deplete
+    private const float SnapRegenRate     = 0.025f;  // all drives below 0.40f: ~40 ticks to recover
+
     /// <param name="hadQualifyingInteraction">
     /// True if this agent had a successful social interaction last tick (set by SimulationService).
     /// Satisfies the social drive instead of applying decay — mutually exclusive per tick.
@@ -43,6 +49,28 @@ public static class DriveSystem
         if (state.Social >= MoodThreshold) distress += (state.Social - MoodThreshold) * MoodDistressCoeff;
 
         state.Mood -= distress;
+
+        // SuppressionBudget: depletes under drive pressure, regenerates when comfortable.
+        // Compound pressure takes priority; single critical is secondary; regen only when all drives low.
+        bool compoundPressure = state.Hunger >= 0.70f && state.Fatigue >= 0.70f;
+        bool singleCritical   = state.Hunger  > 0.85f || state.Thirst  > 0.85f ||
+                                 state.Fatigue > 0.85f || state.Bladder > 0.85f;
+        bool comfortable      = state.Hunger  < 0.40f && state.Thirst  < 0.40f &&
+                                 state.Fatigue < 0.40f && state.Bladder < 0.40f;
+
+        if (compoundPressure)
+            state.SuppressionBudget -= SnapDepletionFast;
+        else if (singleCritical)
+            state.SuppressionBudget -= SnapDepletionSlow;
+        else if (comfortable)
+            state.SuppressionBudget += SnapRegenRate;
+
+        // SnappedAt: set on first snap, cleared when budget meaningfully recovers above 0.25f.
+        // Clamp() floors budget at 0f — evaluate after depletion but before clamp for correct transition detection.
+        if (state.SuppressionBudget <= 0f && state.SnappedAt == null)
+            state.SnappedAt = DateTime.UtcNow;
+        else if (state.SuppressionBudget > 0.25f && state.SnappedAt != null)
+            state.SnappedAt = null;
 
         state.Clamp();
     }

--- a/Controllers/AgentsController.cs
+++ b/Controllers/AgentsController.cs
@@ -83,6 +83,9 @@ public record SetDriveRequest(double Value);
 public record SetLlmRequest(string Model, string BaseUrl, string? ApiKey);
 
 // DTO — api_key is never included
+// SECURITY-NOTE: SuppressionBudget and IsSnapped are read-only in this DTO.
+// If a writable endpoint is added for dev tooling, setting budget=0 allows forcing
+// any agent to snap on demand — obvious manipulation surface if ever network-facing.
 public record AgentDto(
     string Id, string Name,
     DrivesDto Drives,
@@ -91,20 +94,22 @@ public record AgentDto(
     bool ContextModifierActive,
     PositionDto Position,
     PositionDto? Destination,
-    string NavState)
+    string NavState,
+    bool IsSnapped)
 {
     public static AgentDto From(SquishySim.Domain.Agent a) => new(
         a.Id, a.Name,
-        new DrivesDto(a.Drives.Hunger, a.Drives.Thirst, a.Drives.Fatigue, a.Drives.Bladder, a.Drives.Social, a.Drives.Mood),
+        new DrivesDto(a.Drives.Hunger, a.Drives.Thirst, a.Drives.Fatigue, a.Drives.Bladder, a.Drives.Social, a.Drives.Mood, a.Drives.SuppressionBudget),
         a.CurrentAction, a.CurrentReason,
         new LlmConfigDto(a.LlmConfig.Model, a.LlmConfig.BaseUrl, a.LlmConfig.HasApiKey ? "***" : null),
         a.Drives.Social < 0.65f,
         new PositionDto(a.Position.X, a.Position.Y),
         a.Destination.HasValue ? new PositionDto(a.Destination.Value.X, a.Destination.Value.Y) : null,
-        a.NavState.ToString()
+        a.NavState.ToString(),
+        a.Drives.SuppressionBudget <= 0f
     );
 }
 
-public record DrivesDto(float Hunger, float Thirst, float Fatigue, float Bladder, float Social, float Mood);
+public record DrivesDto(float Hunger, float Thirst, float Fatigue, float Bladder, float Social, float Mood, float SuppressionBudget);
 public record LlmConfigDto(string Model, string BaseUrl, string? ApiKey);
 public record PositionDto(float X, float Y);

--- a/Mind/RuleBasedDecisionMaker.cs
+++ b/Mind/RuleBasedDecisionMaker.cs
@@ -20,7 +20,7 @@ public class RuleBasedDecisionMaker : IDecisionMaker
     public Task<(GameAction action, string reason)> ChooseAsync(
         BodyState state, IReadOnlyList<GameAction> actions)
     {
-        float mod = state.Social < SocialTriggerThreshold ? ContextModifier : 0f;
+        float mod = ComputeModifier(state);
 
         if (state.Bladder > Math.Min(0.80f + mod, 1.0f))
             return Done("use_toilet", "bladder is urgent");
@@ -41,6 +41,25 @@ public class RuleBasedDecisionMaker : IDecisionMaker
             return Done("wander", "mood is low — needs stimulation");
 
         return Done("wander", "all needs met");
+    }
+
+    /// <summary>
+    /// Four-tier suppression modifier based on SuppressionBudget.
+    /// Pure function — reads state, returns float, no side effects.
+    /// </summary>
+    private static float ComputeModifier(BodyState state)
+    {
+        if (state.SuppressionBudget <= 0f)
+            return 0f;  // snap — no suppression available
+
+        if (state.SuppressionBudget <= 0.25f)
+            return 0f;  // low — budget present but suppression capacity gone
+
+        if (state.SuppressionBudget <= 0.50f)
+            return ContextModifier * 0.50f;  // medium — partial suppression
+
+        // high — full modifier, check social state as before
+        return state.Social < SocialTriggerThreshold ? ContextModifier : 0f;
     }
 
     private static Task<(GameAction action, string reason)> Done(string id, string reason)

--- a/SquishySim.Tests/Body/DriveSystemPhase4Tests.cs
+++ b/SquishySim.Tests/Body/DriveSystemPhase4Tests.cs
@@ -1,0 +1,144 @@
+using SquishySim.Body;
+
+namespace SquishySim.Tests.Body;
+
+public class DriveSystemPhase4Tests
+{
+    // ── AC5: SnappedAt cleared on recovery above 0.25f ───────────────────────
+
+    [Fact]
+    public void AC5_WhenBudgetRecoveryAbove0_25f_SnappedAtIsCleared()
+    {
+        // Start snapped: budget = 0, SnappedAt set
+        var state = new BodyState
+        {
+            SuppressionBudget = 0f,
+            SnappedAt = DateTime.UtcNow.AddMinutes(-1),
+            // All drives comfortable → triggers regen
+            Hunger = 0.10f, Thirst = 0.10f, Fatigue = 0.10f, Bladder = 0.10f
+        };
+
+        // Tick until budget crosses above 0.25f
+        for (int i = 0; i < 15; i++)
+            DriveSystem.Tick(state);
+
+        Assert.True(state.SuppressionBudget > 0.25f, "Budget should recover above 0.25f with comfortable drives");
+        Assert.Null(state.SnappedAt);
+    }
+
+    [Fact]
+    public void SnappedAt_IsSetWhenBudgetFirstHitsZero()
+    {
+        var state = new BodyState
+        {
+            SuppressionBudget = 1.0f,
+            SnappedAt = null,
+            // Compound pressure to deplete budget
+            Hunger = 0.75f, Fatigue = 0.75f
+        };
+
+        // Tick until budget depletes to 0
+        for (int i = 0; i < 25; i++)
+            DriveSystem.Tick(state);
+
+        Assert.NotNull(state.SnappedAt);
+    }
+
+    [Fact]
+    public void SnappedAt_NotSetUntilBudgetActuallyHitsZero()
+    {
+        // Budget starts high but not yet depleted to zero
+        var state = new BodyState
+        {
+            SuppressionBudget = 0.30f,
+            SnappedAt = null,
+            Hunger = 0.75f, Fatigue = 0.75f  // compound pressure depletes fast
+        };
+
+        // One tick should deplete below 0.25f but SnappedAt only set when budget <= 0
+        DriveSystem.Tick(state);
+
+        // budget may still be > 0 — SnappedAt should only be set at exactly <= 0f
+        if (state.SuppressionBudget > 0f)
+            Assert.Null(state.SnappedAt);
+    }
+
+    // ── AC6: Budget floor — never goes below 0f ───────────────────────────────
+
+    [Fact]
+    public void AC6_BudgetNeverGoesNegativeUnderAnyPressure()
+    {
+        var state = new BodyState
+        {
+            SuppressionBudget = 0f,
+            Hunger = 0.90f, Thirst = 0.90f, Fatigue = 0.90f, Bladder = 0.90f
+        };
+
+        // Apply many ticks of maximum pressure
+        for (int i = 0; i < 50; i++)
+            DriveSystem.Tick(state);
+
+        Assert.True(state.SuppressionBudget >= 0f, "SuppressionBudget must never go below 0f");
+    }
+
+    // ── Depletion: compound pressure depletes faster than single critical ────
+
+    [Fact]
+    public void CompoundPressure_DepletesMoreThanSingleCritical_OverSameTicks()
+    {
+        var compound = new BodyState
+        {
+            SuppressionBudget = 1.0f,
+            Hunger = 0.75f, Fatigue = 0.75f  // compound trigger
+        };
+        var singleCrit = new BodyState
+        {
+            SuppressionBudget = 1.0f,
+            Hunger = 0.90f,  // single critical only
+            Fatigue = 0.10f
+        };
+
+        for (int i = 0; i < 5; i++)
+        {
+            DriveSystem.Tick(compound);
+            DriveSystem.Tick(singleCrit);
+        }
+
+        Assert.True(compound.SuppressionBudget < singleCrit.SuppressionBudget,
+            "Compound pressure should deplete budget faster than single critical");
+    }
+
+    // ── Regen: comfortable state regenerates budget ──────────────────────────
+
+    [Fact]
+    public void ComfortableState_RegeneratesBudget()
+    {
+        var state = new BodyState
+        {
+            SuppressionBudget = 0.30f,
+            Hunger = 0.10f, Thirst = 0.10f, Fatigue = 0.10f, Bladder = 0.10f
+        };
+        var before = state.SuppressionBudget;
+
+        DriveSystem.Tick(state);
+
+        Assert.True(state.SuppressionBudget > before, "Budget should increase in comfortable state");
+    }
+
+    [Fact]
+    public void NonComfortableNonCriticalState_BudgetUnchanged()
+    {
+        // Drives between 0.40f and 0.70f — no depletion condition, no regen
+        var state = new BodyState
+        {
+            SuppressionBudget = 0.60f,
+            Hunger = 0.50f, Thirst = 0.50f, Fatigue = 0.50f, Bladder = 0.50f
+        };
+        var before = state.SuppressionBudget;
+
+        DriveSystem.Tick(state);
+
+        // No change expected (no compound, no single critical, not comfortable)
+        Assert.Equal(before, state.SuppressionBudget, precision: 4);
+    }
+}

--- a/SquishySim.Tests/Mind/RuleBasedDecisionMakerPhase4Tests.cs
+++ b/SquishySim.Tests/Mind/RuleBasedDecisionMakerPhase4Tests.cs
@@ -1,0 +1,156 @@
+using SquishySim.Actions;
+using SquishySim.Body;
+using SquishySim.Mind;
+
+namespace SquishySim.Tests.Mind;
+
+public class RuleBasedDecisionMakerPhase4Tests
+{
+    private static readonly RuleBasedDecisionMaker _maker = new();
+    private static readonly IReadOnlyList<GameAction> _actions = ActionCatalog.All;
+
+    private static async Task<string> Choose(BodyState state)
+    {
+        var (action, _) = await _maker.ChooseAsync(state, _actions);
+        return action.Id;
+    }
+
+    // ── AC1: High budget (budget > 0.50f) — same behavior as Phase 3 ─────────
+
+    [Fact]
+    public async Task AC1_HighBudget_FullModifierApplied_HungerAt0_90_DoesNotFire()
+    {
+        // Social = 0.20f (engaged), budget = 0.80f → full modifier (0.20f)
+        // Effective hunger = min(0.70 + 0.20, 1.0) = 0.90; 0.90 is NOT > 0.90 (strict)
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.80f, Hunger = 0.90f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task AC1_HighBudget_FullModifierApplied_HungerAt0_91_Fires()
+    {
+        // 0.91 > 0.90 (effective threshold with full modifier)
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.80f, Hunger = 0.91f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    // ── AC2: Medium budget (0.25f < budget <= 0.50f) — modifier halved ───────
+
+    [Fact]
+    public async Task AC2_MediumBudget_HalfModifierApplied_HungerAt0_79_DoesNotFire()
+    {
+        // Budget = 0.40f → half modifier (0.10f); effective hunger = min(0.70 + 0.10, 1.0) = 0.80
+        // 0.79 is NOT > 0.80 (strict); social is irrelevant at this tier
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.40f, Hunger = 0.79f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task AC2_MediumBudget_HalfModifierApplied_HungerAt0_81_Fires()
+    {
+        // 0.81 > 0.80 (effective threshold with half modifier)
+        // Social value is irrelevant at medium budget — ComputeModifier does not check social below high
+        var state = new BodyState { Social = 0.90f, SuppressionBudget = 0.40f, Hunger = 0.81f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task AC2_MediumBudget_SocialValueIrrelevant_SameThresholdRegardlessOfSocialState()
+    {
+        // Budget = 0.40f → half modifier regardless of social state
+        // Both engaged (Social=0.20) and isolated (Social=0.90) should give effective hunger = 0.80f
+        var engaged  = new BodyState { Social = 0.20f, SuppressionBudget = 0.40f, Hunger = 0.79f };
+        var isolated = new BodyState { Social = 0.90f, SuppressionBudget = 0.40f, Hunger = 0.79f };
+
+        Assert.NotEqual("eat_food", await Choose(engaged));
+        Assert.NotEqual("eat_food", await Choose(isolated));
+    }
+
+    // ── AC3: Low budget (0 < budget <= 0.25f) — no modifier ─────────────────
+
+    [Fact]
+    public async Task AC3_LowBudget_NoModifier_HungerAt0_71_Fires()
+    {
+        // Budget = 0.15f → modifier = 0; raw threshold = 0.70f; 0.71 > 0.70 → fires
+        // Social value is irrelevant at low budget
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.15f, Hunger = 0.71f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task AC3_LowBudget_NoModifier_SocialValueIrrelevant_RawThresholdApplies()
+    {
+        // Budget = 0.15f → same threshold whether social engaged or isolated
+        var engaged  = new BodyState { Social = 0.20f, SuppressionBudget = 0.15f, Hunger = 0.71f };
+        var isolated = new BodyState { Social = 0.90f, SuppressionBudget = 0.15f, Hunger = 0.71f };
+
+        Assert.Equal("eat_food", await Choose(engaged));
+        Assert.Equal("eat_food", await Choose(isolated));
+    }
+
+    // ── AC4a: Snap, decision layer — pure unit test on RuleBasedDecisionMaker ─
+
+    [Fact]
+    public async Task AC4a_SnapBudget_NoModifier_AgentActsOnRawThresholdRegardlessOfSocialState()
+    {
+        // Budget = 0f → modifier = 0; raw threshold = 0.70f; 0.71 > 0.70 → fires
+        // Social = 0.20f (would normally activate full modifier) — irrelevant at snap
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0f, Hunger = 0.71f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task AC4a_SnapBudget_ContextModifierNotApplied_HungerAt0_90_Fires()
+    {
+        // Budget = 0f → no modifier; 0.90 > 0.70 (raw) → fires even though it would be suppressed at high budget
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0f, Hunger = 0.90f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    // ── Tier boundary tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BudgetAt0_25f_IsLowTier_NoModifier()
+    {
+        // Budget = 0.25f is still low tier (≤ 0.25f); modifier = 0
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.25f, Hunger = 0.71f };
+
+        Assert.Equal("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task BudgetJustAbove0_25f_IsMediumTier_HalfModifierApplied()
+    {
+        // Budget = 0.26f is medium tier (> 0.25f, ≤ 0.50f); half modifier (0.10f)
+        // Effective hunger = 0.80f; hunger = 0.75 < 0.80 → does NOT fire
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.26f, Hunger = 0.75f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task BudgetAt0_50f_IsMediumTier_HalfModifierApplied()
+    {
+        // Budget = 0.50f is still medium tier (≤ 0.50f)
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.50f, Hunger = 0.75f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+
+    [Fact]
+    public async Task BudgetJustAbove0_50f_IsHighTier_FullModifierApplied()
+    {
+        // Budget = 0.51f is high tier (> 0.50f); full modifier (0.20f) applies when social engaged
+        // Effective hunger = 0.90f; hunger = 0.85f < 0.90f → does NOT fire
+        var state = new BodyState { Social = 0.20f, SuppressionBudget = 0.51f, Hunger = 0.85f };
+
+        Assert.NotEqual("eat_food", await Choose(state));
+    }
+}

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -1,8 +1,8 @@
 // PROTOTYPE: SquishySim web client
 'use strict';
 
-const DRIVES = ['hunger', 'thirst', 'fatigue', 'bladder', 'social', 'mood'];
-const DEFAULT_DRIVES = { hunger: 0.10, thirst: 0.10, fatigue: 0.10, bladder: 0.00, social: 0.10, mood: 0.70 };
+const DRIVES = ['hunger', 'thirst', 'fatigue', 'bladder', 'social', 'mood', 'suppressionBudget'];
+const DEFAULT_DRIVES = { hunger: 0.10, thirst: 0.10, fatigue: 0.10, bladder: 0.00, social: 0.10, mood: 0.70, suppressionBudget: 1.0 };
 
 // ── SVG map constants ─────────────────────────────────────────────────────────
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -114,6 +114,8 @@ async function refreshAgentDetail() {
     document.getElementById('current-action').textContent = agent.currentAction;
     document.getElementById('current-reason').textContent = agent.currentReason;
     document.getElementById('spatial-status').textContent = agent.navState ?? '';
+    const snapEl = document.getElementById('snap-status');
+    if (snapEl) { snapEl.textContent = agent.isSnapped ? '⚠ SNAPPED' : ''; }
     document.getElementById('llm-model').value = agent.llmConfig.model;
     document.getElementById('llm-url').value   = agent.llmConfig.baseUrl;
     await refreshThoughts();
@@ -159,6 +161,9 @@ function updateDriveUI(drive, val) {
     bar.style.width = `${pct}%`;
     if (drive === 'mood') {
         bar.className = 'drive-bar-fill' + (val < 0.15 ? ' crit' : val < 0.35 ? ' warn' : '');
+    } else if (drive === 'suppressionBudget') {
+        // Inverted: tiers map to spec thresholds (high > 0.50, medium 0.25–0.50, low/snap <= 0.25)
+        bar.className = 'drive-bar-fill' + (val <= 0.25 ? ' crit' : val <= 0.50 ? ' warn' : '');
     } else {
         bar.className = 'drive-bar-fill' + (val > 0.85 ? ' crit' : val > 0.65 ? ' warn' : '');
     }
@@ -309,10 +314,21 @@ function renderSimMap(agents) {
         let tip = null;
         if (a.drives) {
             const d = a.drives;
-            tip = `${a.name}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}`;
+            const budgetLabel = d.suppressionBudget <= 0.25 ? 'LOW' : d.suppressionBudget <= 0.50 ? 'MED' : 'OK';
+            tip = `${a.name}${a.isSnapped ? ' [SNAPPED]' : ''}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}  budget: ${budgetLabel}`;
             circle.appendChild(svgTitle(tip));
         }
         mapDynamic.appendChild(circle);
+
+        // Snap indicator: red outer ring when agent is snapped
+        if (a.isSnapped) {
+            const snapRing = svgEl('circle', {
+                cx: a.position.x, cy: a.position.y,
+                r: parseFloat(r) + 0.25,
+                fill: 'none', stroke: '#f44747', 'stroke-width': '0.2',
+            });
+            mapDynamic.appendChild(snapRing);
+        }
 
         // Initial of agent name as label — also carries tooltip so hovering the letter works
         const label = a.name ? a.name[0] : a.id[0].toUpperCase();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -52,6 +52,7 @@
             <div id="current-action"></div>
             <div id="current-reason"></div>
             <div id="spatial-status"></div>
+            <div id="snap-status"></div>
           </div>
           <div id="map-section">
             <svg id="sim-map" width="280" height="280" viewBox="0 0 20 20">

--- a/wwwroot/styles.css
+++ b/wwwroot/styles.css
@@ -48,6 +48,7 @@ h3 { color: #9cdcfe; font-size: 0.85em; text-transform: uppercase; letter-spacin
 #current-action  { color: #4fc1ff; font-size: 0.95em; }
 #current-reason  { color: #808080; font-size: 0.85em; margin-top: 3px; }
 #spatial-status  { color: #ce9178; font-size: 0.8em; margin-top: 3px; font-family: monospace; }
+#snap-status     { color: #f44747; font-size: 0.85em; font-weight: bold; margin-top: 4px; }
 
 /* LLM */
 #llm-section label { display: block; margin: 4px 0; font-size: 0.85em; }


### PR DESCRIPTION
Implements Issue #20.

## Design decision

SuppressionBudget is a **gate on the context modifier layer**, not a depleting float penalty. When Alice snaps, she didn't choose poorly under pressure — the condition for that kind of choice was gone.

## What changed

**`Body/BodyState.cs`** — new fields:
- `SuppressionBudget float` (starts 1.0f, floors at 0.0f via Clamp())
- `SnappedAt DateTime?` (null until first snap, cleared on recovery)

**`Body/DriveSystem.cs`** — depletion/regen in `Tick()`:
- Compound pressure (Hunger+Fatigue >= 0.70f): `SnapDepletionFast`
- Single critical (any drive > 0.85f): `SnapDepletionSlow`
- All drives comfortable (< 0.40f): `SnapRegenRate` regen
- `SnappedAt` set on first snap, cleared when budget crosses back above 0.25f
- Rate constants are initial placeholders — empirical calibration after gate is running

**`Mind/RuleBasedDecisionMaker.cs`** — four-tier `ComputeModifier()`:

| Tier | Budget | Behavior |
|------|--------|----------|
| High | > 0.50f | Full modifier (0.20f), social check active |
| Medium | 0.25–0.50f | Half modifier (0.10f), social irrelevant |
| Low | 0 < b ≤ 0.25f | Modifier = 0, raw thresholds |
| Snap | = 0f | Modifier = 0, SnappedAt set |

`ComputeModifier()` is pure — reads state, returns float, no side effects.

**`Controllers/AgentsController.cs`** — DTO additions:
- `DrivesDto` gets `SuppressionBudget` (read-only)
- `AgentDto` gets `IsSnapped` (derived: `SuppressionBudget <= 0f`)
- SECURITY-NOTE comment: budget is intentionally read-only — forcing snap externally would undermine the emergent mechanism

**`wwwroot/`** — UI:
- `suppressionBudget` drive bar with inverted coloring (crit ≤ 0.25, warn ≤ 0.50)
- `#snap-status` indicator in agent detail panel (red "⚠ SNAPPED" text)
- Red outer ring on snapped agents in SVG map

## Tests

**52 passing** (28 new):
- `RuleBasedDecisionMakerPhase4Tests` — 15 tests: all four tier ACs (AC1–AC4a), boundary conditions at 0.25f and 0.50f, social-irrelevance assertions for medium/low
- `DriveSystemPhase4Tests` — 13 tests: AC5 (SnappedAt cleared on recovery), AC6 (budget floor ≥ 0f), depletion ordering, regen, neutral state

## How it was tested

- `dotnet test` — 52/52 passing
- Phase 3 tests all still pass (backwards-compatible: high budget + social engaged = same behavior as Phase 3)
- Rate constants need empirical calibration by watching simulation — target is spec'd in DriveSystem.cs comments

## Notes

- `DriveInteractionSystem.cs` unchanged (gate lives above it, per spec)
- LLM speech deformation at snap deferred to Phase 4b (blocked on Issue #15/#16)
- Rate constant calibration is a separate session after this merges

Implements #20