### PR TITLE
Enrich LLM prompt context, add per-agent persona, and replace resource icons

### DIFF
--- a/Domain/Agent.cs
+++ b/Domain/Agent.cs
@@ -6,8 +6,9 @@ namespace SquishySim.Domain;
 // PROTOTYPE: Agent domain model — wraps biological drives + decision-making + history
 public class Agent
 {
-    public string Id   { get; init; } = "";
-    public string Name { get; init; } = "";
+    public string  Id      { get; init; } = "";
+    public string  Name    { get; init; } = "";
+    public string? Persona { get; init; }  // Optional per-agent personality string passed to LLM prompt
 
     public BodyState Drives { get; init; } = new();
 

--- a/Mind/IDecisionMaker.cs
+++ b/Mind/IDecisionMaker.cs
@@ -9,5 +9,7 @@ public interface IDecisionMaker
 
     Task<(GameAction action, string reason)> ChooseAsync(
         BodyState state,
-        IReadOnlyList<GameAction> actions);
+        IReadOnlyList<GameAction> actions,
+        string? persona = null,
+        string? navState = null);
 }

--- a/Mind/OllamaDecisionMaker.cs
+++ b/Mind/OllamaDecisionMaker.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using SquishySim.Actions;
@@ -25,9 +26,10 @@ public class OllamaDecisionMaker : IDecisionMaker
     }
 
     public async Task<(GameAction action, string reason)> ChooseAsync(
-        BodyState state, IReadOnlyList<GameAction> actions)
+        BodyState state, IReadOnlyList<GameAction> actions,
+        string? persona = null, string? navState = null)
     {
-        var prompt = PromptBuilder.Build(state, actions);
+        var prompt = PromptBuilder.Build(state, actions, persona, navState);
 
         var requestJson = JsonSerializer.Serialize(new
         {
@@ -37,7 +39,10 @@ public class OllamaDecisionMaker : IDecisionMaker
         });
 
         var content = new StringContent(requestJson, Encoding.UTF8, "application/json");
+        var sw = Stopwatch.StartNew();
         var response = await _http.PostAsync($"{_baseUrl}/api/generate", content);
+        sw.Stop();
+        Console.WriteLine($"[LLM] {_model} inference: {sw.ElapsedMilliseconds}ms");
         response.EnsureSuccessStatusCode();
 
         var responseText = await response.Content.ReadAsStringAsync();

--- a/Mind/PromptBuilder.cs
+++ b/Mind/PromptBuilder.cs
@@ -5,22 +5,43 @@ namespace SquishySim.Mind;
 
 public static class PromptBuilder
 {
-    public static string Build(BodyState state, IReadOnlyList<GameAction> actions)
+    public static string Build(
+        BodyState state,
+        IReadOnlyList<GameAction> actions,
+        string? persona = null,
+        string? navState = null)
     {
         var sb = new System.Text.StringBuilder();
 
         sb.AppendLine("You control a simulated creature. Choose the best action given its current biological state.");
+
+        if (!string.IsNullOrEmpty(persona))
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Your disposition: {persona}");
+        }
+
         sb.AppendLine();
         sb.AppendLine("Current state (0.0 = satisfied, 1.0 = critical):");
-        sb.AppendLine($"  hunger:  {state.Hunger:0.00}  ({state.HungerLabel})");
-        sb.AppendLine($"  thirst:  {state.Thirst:0.00}  ({state.ThirstLabel})");
-        sb.AppendLine($"  fatigue: {state.Fatigue:0.00}  ({state.FatigueLabel})");
-        sb.AppendLine($"  bladder: {state.Bladder:0.00}  ({state.BladderLabel})");
-        sb.AppendLine($"  mood:    {state.Mood:0.00}  ({state.MoodLabel}) [higher is better]");
+        sb.AppendLine($"  hunger:   {state.Hunger:0.00}  ({state.HungerLabel})");
+        sb.AppendLine($"  thirst:   {state.Thirst:0.00}  ({state.ThirstLabel})");
+        sb.AppendLine($"  fatigue:  {state.Fatigue:0.00}  ({state.FatigueLabel})");
+        sb.AppendLine($"  bladder:  {state.Bladder:0.00}  ({state.BladderLabel})");
+        sb.AppendLine($"  mood:     {state.Mood:0.00}  ({state.MoodLabel}) [higher is better]");
+        sb.AppendLine($"  social:   {state.Social:0.00}  (isolation; higher = more isolated)");
+        sb.AppendLine($"  budget:   {state.SuppressionBudget:0.00}  (suppression capacity; lower = less able to delay needs)");
+
+        if (state.SnappedAt.HasValue)
+            sb.AppendLine("  ** SNAPPED: suppression capacity exhausted. Act on your needs directly. **");
+
+        if (!string.IsNullOrEmpty(navState))
+            sb.AppendLine($"  movement: {navState}");
+
         sb.AppendLine();
         sb.AppendLine("Available actions and their effects:");
         foreach (var action in actions)
             sb.AppendLine($"  {action.Id}: {action.EffectSummary}");
+
         sb.AppendLine();
         sb.AppendLine("Respond with ONLY a single line of valid JSON. No markdown, no explanation:");
         sb.Append("{\"action\": \"<action_id>\", \"reason\": \"<one short sentence>\"}");

--- a/Mind/RuleBasedDecisionMaker.cs
+++ b/Mind/RuleBasedDecisionMaker.cs
@@ -18,7 +18,8 @@ public class RuleBasedDecisionMaker : IDecisionMaker
     private const float SocialTriggerThreshold = 0.65f;
 
     public Task<(GameAction action, string reason)> ChooseAsync(
-        BodyState state, IReadOnlyList<GameAction> actions)
+        BodyState state, IReadOnlyList<GameAction> actions,
+        string? persona = null, string? navState = null)
     {
         float mod = ComputeModifier(state);
 

--- a/Services/SimulationService.cs
+++ b/Services/SimulationService.cs
@@ -45,18 +45,19 @@ public class SimulationService
         // PROTOTYPE: Seed three agents with rule-based decision makers at spread starting positions
         var seeds = new[]
         {
-            ("alice",   "Alice",   ( 3f, 10f)),
-            ("bob",     "Bob",     (10f,  3f)),
-            ("charlie", "Charlie", (17f, 10f)),
+            ("alice",   "Alice",   ( 3f, 10f), "You tend to hold your physical needs longer than you should to avoid disrupting conversation. You're apologetic when you have to leave."),
+            ("bob",     "Bob",     (10f,  3f), "You act on your drives early and practically. You don't suppress well, but you also don't let things build up. Blunt about what you need."),
+            ("charlie", "Charlie", (17f, 10f), "You're stoic — you can hold competing drives longer than most. But when you finally break, it hits harder than you expected."),
         };
 
-        foreach (var (id, name, pos) in seeds)
+        foreach (var (id, name, pos, persona) in seeds)
         {
             _agents.Add(new Agent
             {
                 Id            = id,
                 Name          = name,
                 Position      = pos,
+                Persona       = persona,
                 DecisionMaker = new RuleBasedDecisionMaker()
             });
         }
@@ -213,7 +214,8 @@ public class SimulationService
                 // PROTOTYPE: .GetResult() holds _lock for the LLM HTTP call duration.
                 // Acceptable for rule-based; Ollama will block. See existing prototype note.
                 var (action, reason) = agent.DecisionMaker
-                    .ChooseAsync(agent.Drives, ActionCatalog.All)
+                    .ChooseAsync(agent.Drives, ActionCatalog.All,
+                        agent.Persona, agent.NavState.ToString())
                     .GetAwaiter().GetResult();
 
                 agent.CurrentAction = action.Id;

--- a/SquishySim.Tests/Mind/PromptBuilderTests.cs
+++ b/SquishySim.Tests/Mind/PromptBuilderTests.cs
@@ -1,0 +1,110 @@
+using SquishySim.Actions;
+using SquishySim.Body;
+using SquishySim.Mind;
+
+namespace SquishySim.Tests.Mind;
+
+public class PromptBuilderTests
+{
+    private static readonly IReadOnlyList<GameAction> _actions = ActionCatalog.All;
+
+    // ── Social drive ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesSocialDrive()
+    {
+        var state = new BodyState { Social = 0.65f };
+        var prompt = PromptBuilder.Build(state, _actions);
+        Assert.Contains("social", prompt);
+        Assert.Contains("0.65", prompt);
+    }
+
+    // ── SuppressionBudget ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesSuppressionBudget()
+    {
+        var state = new BodyState { SuppressionBudget = 0.42f };
+        var prompt = PromptBuilder.Build(state, _actions);
+        Assert.Contains("budget", prompt);
+        Assert.Contains("0.42", prompt);
+    }
+
+    // ── Snap state ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesSnappedWarning_WhenSnapped()
+    {
+        var state = new BodyState { SnappedAt = DateTime.UtcNow };
+        var prompt = PromptBuilder.Build(state, _actions);
+        Assert.Contains("SNAPPED", prompt);
+    }
+
+    [Fact]
+    public void Build_NoSnappedWarning_WhenNotSnapped()
+    {
+        var state = new BodyState { SnappedAt = null };
+        var prompt = PromptBuilder.Build(state, _actions);
+        Assert.DoesNotContain("SNAPPED", prompt);
+    }
+
+    // ── Persona ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesPersona_WhenProvided()
+    {
+        var state = new BodyState();
+        var persona = "You tend to hold your needs longer than you should.";
+        var prompt = PromptBuilder.Build(state, _actions, persona: persona);
+        Assert.Contains(persona, prompt);
+    }
+
+    [Fact]
+    public void Build_NoPersonaSection_WhenPersonaNull()
+    {
+        var state = new BodyState();
+        var prompt = PromptBuilder.Build(state, _actions, persona: null);
+        Assert.DoesNotContain("disposition", prompt);
+    }
+
+    [Fact]
+    public void Build_NoPersonaSection_WhenPersonaEmpty()
+    {
+        var state = new BodyState();
+        var prompt = PromptBuilder.Build(state, _actions, persona: "");
+        Assert.DoesNotContain("disposition", prompt);
+    }
+
+    // ── NavState ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesNavState_WhenProvided()
+    {
+        var state = new BodyState();
+        var prompt = PromptBuilder.Build(state, _actions, navState: "Committed");
+        Assert.Contains("movement", prompt);
+        Assert.Contains("Committed", prompt);
+    }
+
+    [Fact]
+    public void Build_NoNavSection_WhenNavStateNull()
+    {
+        var state = new BodyState();
+        var prompt = PromptBuilder.Build(state, _actions, navState: null);
+        Assert.DoesNotContain("movement", prompt);
+    }
+
+    // ── Core drives still present ─────────────────────────────────────────────
+
+    [Fact]
+    public void Build_IncludesCoreDrivers()
+    {
+        var state = new BodyState { Hunger = 0.55f, Thirst = 0.30f, Fatigue = 0.70f };
+        var prompt = PromptBuilder.Build(state, _actions);
+        Assert.Contains("hunger", prompt);
+        Assert.Contains("thirst", prompt);
+        Assert.Contains("fatigue", prompt);
+        Assert.Contains("bladder", prompt);
+        Assert.Contains("mood", prompt);
+    }
+}

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -15,10 +15,20 @@ const AGENT_COLORS = {
 };
 
 const RESOURCES = [
-    { x: 5,  y: 5,  fill: '#81c784', label: 'F', name: 'Food' },
-    { x: 15, y: 5,  fill: '#4fc3f7', label: 'W', name: 'Water' },
-    { x: 15, y: 15, fill: '#bcaaa4', label: 'T', name: 'Latrine' },
-    { x: 5,  y: 15, fill: '#ffb74d', label: 'S', name: 'Shelter' },
+    { x: 5,  y: 5,  name: 'Food',    elements: [
+        { tag: 'circle',  attrs: { cx: 5,     cy: 5,     r: 0.38, fill: 'none', stroke: '#81c784', 'stroke-width': 0.10 } },
+        { tag: 'circle',  attrs: { cx: 5,     cy: 5,     r: 0.15, fill: '#81c784' } },
+    ]},
+    { x: 15, y: 5,  name: 'Water',   elements: [
+        { tag: 'path',    attrs: { d: 'M15,4.55 L15.35,5.05 Q15.35,5.42 15,5.42 Q14.65,5.42 14.65,5.05 Z', fill: '#4fc3f7' } },
+    ]},
+    { x: 15, y: 15, name: 'Latrine', elements: [
+        { tag: 'rect',    attrs: { x: 14.88, y: 14.62, width: 0.24, height: 0.76, rx: 0.04, fill: '#bcaaa4' } },
+        { tag: 'rect',    attrs: { x: 14.62, y: 14.88, width: 0.76, height: 0.24, rx: 0.04, fill: '#bcaaa4' } },
+    ]},
+    { x: 5,  y: 15, name: 'Shelter', elements: [
+        { tag: 'polygon', attrs: { points: '5,14.55 5.42,15.42 4.58,15.42', fill: '#ffb74d' } },
+    ]},
 ];
 
 let selectedAgentId = null;
@@ -254,19 +264,13 @@ function initMapStatic() {
         g.appendChild(svgEl('line', { x1: 0, y1: i, x2: 20, y2: i, stroke: '#2a2a2a', 'stroke-width': '0.1' }));
     }
 
-    // Resource icons: 1×1 square centered on position, with 1-char label + tooltip
+    // Resource icons: distinct SVG shapes per resource type, with tooltip on first element
     RESOURCES.forEach(r => {
-        const rect = svgEl('rect', { x: r.x - 0.5, y: r.y - 0.5, width: 1, height: 1, fill: r.fill });
-        rect.appendChild(svgTitle(r.name));
-        g.appendChild(rect);
-        const t = svgEl('text', {
-            x: r.x, y: r.y,
-            'font-size': '0.8', fill: '#1a1a1a',
-            'text-anchor': 'middle', 'dominant-baseline': 'central',
-            cursor: 'default',
+        r.elements.forEach((e, i) => {
+            const el = svgEl(e.tag, e.attrs);
+            if (i === 0) el.appendChild(svgTitle(r.name));
+            g.appendChild(el);
         });
-        t.textContent = r.label;
-        g.appendChild(t);
     });
 }
 


### PR DESCRIPTION
## Summary

- **Issue #16 (richer prompts + persona):** PromptBuilder now sends social, suppressionBudget, snap state, navState, and per-agent persona strings to the LLM. Alice/Bob/Charlie each have distinct dispositions matching Phase 4b suppression arc design.
- **Resource icons:** SVG plate/teardrop/cross/triangle replace the rect+letter icons in `initMapStatic()`. Path strings designed by Gus, same fill colors as existing spec.
- **Latency instrumentation:** `OllamaDecisionMaker` wraps `PostAsync` with Stopwatch, logs `[LLM] {model} inference: {ms}ms` to console per call.
- **IDecisionMaker interface:** Optional `persona` and `navState` params added (backward-compatible — all existing callers work unchanged).
- **Mock seam:** `IDecisionMaker` remains an interface; tests use `RuleBasedDecisionMaker` or inject fakes directly — no live Ollama required.

## What changed

| File | Change |
|------|--------|
| `Domain/Agent.cs` | Added `Persona` string field |
| `Mind/IDecisionMaker.cs` | Optional `persona`, `navState` params on `ChooseAsync` |
| `Mind/PromptBuilder.cs` | Adds social, budget, snap warning, navState, persona to prompt |
| `Mind/OllamaDecisionMaker.cs` | Passes context to PromptBuilder; Stopwatch latency log |
| `Mind/RuleBasedDecisionMaker.cs` | Updated signature (ignores extra params) |
| `Services/SimulationService.cs` | Seeds persona per agent; passes context to ChooseAsync |
| `SquishySim.Tests/Mind/PromptBuilderTests.cs` | 11 new tests for all prompt fields |
| `wwwroot/app.js` | RESOURCES uses element descriptors; initMapStatic renders icons |

## Test plan

- 82/82 tests passing (11 new PromptBuilder tests)
- PromptBuilder tests verify: social/budget in output, SNAPPED warning present/absent, persona included/excluded, navState present/absent, core drives still present
- RuleBasedDecisionMaker tests unchanged — optional params are backward-compatible
- Verified build is clean

## Notes

- Parallel tick loop (Issue #23) is a separate PR — sequential calls work fine for development
- Rate constant calibration (SnapDepletionFast) still pending post-merge observation