### PR TITLE
Add AC4b controller/HTTP-layer tests for IsSnapped DTO field

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -25,3 +25,6 @@ var sim = app.Services.GetRequiredService<SimulationService>();
 sim.StartAutoAdvance();
 
 app.Run();
+
+// Expose Program class to WebApplicationFactory<Program> in test project
+public partial class Program { }

--- a/SquishySim.Tests/Controllers/AgentsControllerTests.cs
+++ b/SquishySim.Tests/Controllers/AgentsControllerTests.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using SquishySim.Services;
+
+namespace SquishySim.Tests.Controllers;
+
+/// <summary>
+/// AC4b — Controller/HTTP-layer assertion that IsSnapped=true appears in the agents
+/// DTO when SuppressionBudget=0f. Separate from AC4a (pure RuleBasedDecisionMaker
+/// unit test) to verify the DTO derivation layer independently.
+/// </summary>
+public class AgentsControllerTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public AgentsControllerTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    // ── AC4b ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AC4b_WhenSuppressionBudgetIsZero_IsSnappedIsTrueInDto()
+    {
+        // Arrange: pause simulation to prevent ticks from modifying budget during test,
+        // then set alice's budget to 0f directly through the service.
+        var sim = _factory.Services.GetRequiredService<SimulationService>();
+        sim.Pause();
+
+        var alice = sim.GetAgent("alice");
+        Assert.NotNull(alice);
+        alice.Drives.SuppressionBudget = 0f;
+
+        // Act: GET /agents/alice through HTTP layer
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/agents/alice");
+        response.EnsureSuccessStatusCode();
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        // Assert: isSnapped is true, suppressionBudget is 0 in the DTO
+        var drives = json.RootElement.GetProperty("drives");
+        Assert.Equal(0f, drives.GetProperty("suppressionBudget").GetSingle());
+        Assert.True(json.RootElement.GetProperty("isSnapped").GetBoolean());
+    }
+
+    [Fact]
+    public async Task AC4b_WhenSuppressionBudgetAboveZero_IsSnappedIsFalseInDto()
+    {
+        // Contrast: budget > 0f → isSnapped = false
+        var sim = _factory.Services.GetRequiredService<SimulationService>();
+        sim.Pause();
+
+        var alice = sim.GetAgent("alice");
+        Assert.NotNull(alice);
+        alice.Drives.SuppressionBudget = 0.50f;
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/agents/alice");
+        response.EnsureSuccessStatusCode();
+
+        var json = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.False(json.RootElement.GetProperty("isSnapped").GetBoolean());
+    }
+}

--- a/SquishySim.Tests/SquishySim.Tests.csproj
+++ b/SquishySim.Tests/SquishySim.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />


### PR DESCRIPTION
## Summary

- Adds `WebApplicationFactory<Program>` test infrastructure to `SquishySim.Tests`
- Exposes the `Program` entry point via `public partial class Program {}` in `Program.cs`
- Adds `Microsoft.AspNetCore.Mvc.Testing` 8.0.0 package reference to test project
- Two tests in `SquishySim.Tests/Controllers/AgentsControllerTests.cs`:
  - `AC4b_WhenSuppressionBudgetIsZero_IsSnappedIsTrueInDto` — sets alice's budget to 0f, GETs `/agents/alice`, asserts `isSnapped: true` and `suppressionBudget: 0` in the JSON response
  - `AC4b_WhenSuppressionBudgetAboveZero_IsSnappedIsFalseInDto` — contrast: budget = 0.5f → `isSnapped: false`

Closes #22

## Why separate from AC4a (PR #21)?

AC4a tests `RuleBasedDecisionMaker.ComputeModifier()` in isolation (pure unit). AC4b tests the controller/DTO derivation layer independently: verifies that `IsSnapped = a.Drives.SuppressionBudget <= 0f` is correctly projected through the HTTP response, not assumed from the unit test coverage.

## Test plan

- [ ] `dotnet test SquishySim.Tests/SquishySim.Tests.csproj --filter "FullyQualifiedName~AgentsController"` → 2 tests pass
- [ ] Full suite: `dotnet test SquishySim.Tests/SquishySim.Tests.csproj` → all tests pass (82+ tests)
- Simulation is paused before mutating `alice.Drives.SuppressionBudget` to prevent tick interference during the HTTP round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)