### PR TITLE
Add social isolation coherence — two-layer behavioral and cognitive model

### DIFF
--- a/Body/CoherenceDegradationSystem.cs
+++ b/Body/CoherenceDegradationSystem.cs
@@ -1,0 +1,47 @@
+namespace SquishySim.Body;
+
+/// <summary>
+/// Applies behavioral coherence degradation to drive snapshots under social isolation.
+/// Isolation compresses physical drive urgency differentials toward their mean — the agent
+/// can still feel all drives, but loses the ability to prioritize between them.
+///
+/// This is distinct from SuppressionBudget snap (crisis/overload). Snap = can't suppress any drive.
+/// Coherence degradation = can't distinguish which drive is most urgent.
+/// </summary>
+public static class CoherenceDegradationSystem
+{
+    // Isolation below this threshold produces no compression.
+    private const float IsolationOnsetThreshold = 0.3f;
+
+    /// <summary>
+    /// Returns a modified copy of <paramref name="snapshot"/> with physical drive urgencies
+    /// compressed toward their mean, proportional to the isolation level.
+    /// Social, Mood, and SuppressionBudget are not affected.
+    /// </summary>
+    public static BodyState ApplyToSnapshot(BodyState snapshot)
+    {
+        float isolationFactor = ComputeIsolationFactor(snapshot.Social);
+        if (isolationFactor <= 0f) return snapshot;
+
+        float mean = (snapshot.Hunger + snapshot.Thirst + snapshot.Fatigue + snapshot.Bladder) / 4f;
+
+        snapshot.Hunger  = Lerp(snapshot.Hunger,  mean, isolationFactor);
+        snapshot.Thirst  = Lerp(snapshot.Thirst,  mean, isolationFactor);
+        snapshot.Fatigue = Lerp(snapshot.Fatigue, mean, isolationFactor);
+        snapshot.Bladder = Lerp(snapshot.Bladder, mean, isolationFactor);
+
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Behavioral coherence as a [0, 1] value: 1.0 = fully coherent, 0.0 = fully incoherent.
+    /// Derived from current social isolation level.
+    /// </summary>
+    public static float BehavioralCoherence(float social) =>
+        1.0f - ComputeIsolationFactor(social);
+
+    internal static float ComputeIsolationFactor(float social) =>
+        Math.Max(0f, social - IsolationOnsetThreshold) / (1.0f - IsolationOnsetThreshold);
+
+    private static float Lerp(float a, float b, float t) => a + (b - a) * t;
+}

--- a/Controllers/AgentsController.cs
+++ b/Controllers/AgentsController.cs
@@ -1,5 +1,6 @@
 // PROTOTYPE: Agents REST API
 using Microsoft.AspNetCore.Mvc;
+using SquishySim.Body;
 using SquishySim.Services;
 
 namespace SquishySim.Controllers;
@@ -95,7 +96,9 @@ public record AgentDto(
     PositionDto Position,
     PositionDto? Destination,
     string NavState,
-    bool IsSnapped)
+    bool IsSnapped,
+    float PersonaDriftFactor,
+    float BehavioralCoherence)
 {
     public static AgentDto From(SquishySim.Domain.Agent a) => new(
         a.Id, a.Name,
@@ -106,7 +109,9 @@ public record AgentDto(
         new PositionDto(a.Position.X, a.Position.Y),
         a.Destination.HasValue ? new PositionDto(a.Destination.Value.X, a.Destination.Value.Y) : null,
         a.NavState.ToString(),
-        a.Drives.SuppressionBudget <= 0f
+        a.Drives.SuppressionBudget <= 0f,
+        a.PersonaDriftFactor,
+        CoherenceDegradationSystem.BehavioralCoherence(a.Drives.Social)
     );
 }
 

--- a/Domain/Agent.cs
+++ b/Domain/Agent.cs
@@ -25,6 +25,11 @@ public class Agent
     // consumed by DriveSystem.Tick the following tick to apply social satisfaction.
     public bool HadSocialInteractionLastTick { get; set; } = false;
 
+    // Cognitive drift: accumulates under sustained isolation, recovers with social contact.
+    // 0.0 = fully aligned with base persona; 1.0 = fully drifted.
+    // Mind-layer state — distinct from BodyState. Ticked by CognitiveDriftSystem.
+    public float PersonaDriftFactor { get; set; } = 0.0f;
+
     // ── Spatial state ─────────────────────────────────────────────────────────
 
     public (float X, float Y)  Position    { get; set; } = (10f, 10f);

--- a/Mind/CognitiveDriftSystem.cs
+++ b/Mind/CognitiveDriftSystem.cs
@@ -1,0 +1,48 @@
+using SquishySim.Domain;
+
+namespace SquishySim.Mind;
+
+/// <summary>
+/// Accumulates cognitive drift in agents under sustained social isolation.
+/// PersonaDriftFactor represents divergence from the agent's base persona:
+///   0.0 = fully aligned with base persona
+///   1.0 = fully drifted — identity feels inaccessible
+///
+/// Cognitive drift has a slower time constant than behavioral coherence degradation.
+/// An agent may lose behavioral decisiveness before (or after) their inner voice shifts —
+/// both layers are independently testable.
+/// </summary>
+public static class CognitiveDriftSystem
+{
+    private const float DriftAccumulationRate = 0.005f;  // ~200 ticks isolated → full drift
+    private const float DriftRecoveryRate     = 0.008f;  // ~125 ticks social → clear drift
+
+    private const float IsolationThreshold = 0.50f;  // above this: drift accumulates
+    private const float RecoveryThreshold  = 0.30f;  // below this: drift recovers
+
+    public static void Tick(Agent agent)
+    {
+        if (agent.Drives.Social > IsolationThreshold)
+            agent.PersonaDriftFactor = Math.Min(1.0f, agent.PersonaDriftFactor + DriftAccumulationRate);
+        else if (agent.Drives.Social < RecoveryThreshold)
+            agent.PersonaDriftFactor = Math.Max(0.0f, agent.PersonaDriftFactor - DriftRecoveryRate);
+        // Between thresholds: no change — plateaus at current drift level
+    }
+
+    /// <summary>
+    /// Returns a persona string modified to reflect cognitive drift state.
+    /// </summary>
+    public static string? BuildDriftedPersona(string? basePersona, float driftFactor)
+    {
+        if (string.IsNullOrEmpty(basePersona) || driftFactor < 0.10f)
+            return basePersona;
+
+        if (driftFactor < 0.40f)
+            return basePersona + " Lately you find it harder to concentrate — things that used to matter feel distant.";
+
+        if (driftFactor < 0.70f)
+            return basePersona + " You feel disconnected from yourself. Your usual instincts feel muffled.";
+
+        return basePersona + " The person you were is hard to locate. Your priorities feel interchangeable.";
+    }
+}

--- a/Services/SimulationService.cs
+++ b/Services/SimulationService.cs
@@ -212,6 +212,10 @@ public class SimulationService
             foreach (var agent in _agents)
                 DriveSystem.Tick(agent.Drives, hadInteractionLastTick.Contains(agent.Id));
 
+            // Phase 2b: Cognitive drift tick (mind-layer; different time constant than drives)
+            foreach (var agent in _agents)
+                CognitiveDriftSystem.Tick(agent);
+
             // Snapshot which agents were Idle before decision-making runs.
             // Agents transition to Committed(wander) during the decision phase, which would
             // incorrectly mark them as unavailable for seeking within the same tick.
@@ -221,9 +225,15 @@ public class SimulationService
                 .ToHashSet();
 
             // Snapshot drives + context for each agent.
+            // Apply coherence degradation to the snapshot so decision makers see compressed urgencies
+            // under isolation — both rule-based and Ollama receive the same degraded view.
             // Lock is released before LLM calls — snapshot isolates them from concurrent mutations.
             snapshots = _agents
-                .Select(a => (a, a.Drives.Snapshot(), a.Persona, a.NavState.ToString()))
+                .Select(a => (
+                    a,
+                    CoherenceDegradationSystem.ApplyToSnapshot(a.Drives.Snapshot()),
+                    CognitiveDriftSystem.BuildDriftedPersona(a.Persona, a.PersonaDriftFactor),
+                    a.NavState.ToString()))
                 .ToList();
         }
 
@@ -260,7 +270,7 @@ public class SimulationService
                     d.Agent.CurrentReason = d.Reason!;
                     UpdateNavigation(d.Agent, d.Action, idleAtTickStart);
                     d.Agent.Thoughts.Add(new ThoughtEntry(now,
-                        $"{d.Agent.CurrentAction}: {d.Agent.CurrentReason} | nav={d.Agent.NavState}"));
+                        $"{d.Agent.CurrentAction}: {d.Agent.CurrentReason} | nav={d.Agent.NavState} | drift={d.Agent.PersonaDriftFactor:0.00}"));
                     if (d.Agent.Thoughts.Count > 200) d.Agent.Thoughts.RemoveAt(0);
                 }
 

--- a/SquishySim.Tests/Body/CoherenceDegradationSystemTests.cs
+++ b/SquishySim.Tests/Body/CoherenceDegradationSystemTests.cs
@@ -1,0 +1,132 @@
+using SquishySim.Body;
+
+namespace SquishySim.Tests.Body;
+
+public class CoherenceDegradationSystemTests
+{
+    // ── Below threshold: no compression ──────────────────────────────────────
+
+    [Fact]
+    public void WhenSocialBelowOnsetThreshold_DrivesAreUnchanged()
+    {
+        var snapshot = new BodyState
+        {
+            Hunger = 0.9f, Thirst = 0.1f, Fatigue = 0.3f, Bladder = 0.2f,
+            Social = 0.29f  // just below 0.3 onset threshold
+        };
+
+        var result = CoherenceDegradationSystem.ApplyToSnapshot(snapshot);
+
+        Assert.Equal(0.9f, result.Hunger,  precision: 4);
+        Assert.Equal(0.1f, result.Thirst,  precision: 4);
+        Assert.Equal(0.3f, result.Fatigue, precision: 4);
+        Assert.Equal(0.2f, result.Bladder, precision: 4);
+    }
+
+    [Fact]
+    public void WhenSocialAtOnsetThreshold_DrivesAreUnchanged()
+    {
+        var snapshot = new BodyState
+        {
+            Hunger = 0.8f, Thirst = 0.2f, Fatigue = 0.5f, Bladder = 0.1f,
+            Social = 0.30f  // exactly at threshold → isolationFactor = 0
+        };
+
+        var result = CoherenceDegradationSystem.ApplyToSnapshot(snapshot);
+
+        Assert.Equal(0.8f, result.Hunger,  precision: 4);
+        Assert.Equal(0.2f, result.Thirst,  precision: 4);
+        Assert.Equal(0.5f, result.Fatigue, precision: 4);
+        Assert.Equal(0.1f, result.Bladder, precision: 4);
+    }
+
+    // ── Above threshold: drives compress toward mean ──────────────────────────
+
+    [Fact]
+    public void WhenSocialAboveThreshold_DrivesCompressTowardMean()
+    {
+        // Hunger is high, Thirst is low — under isolation, they should converge
+        var snapshot = new BodyState
+        {
+            Hunger = 0.9f, Thirst = 0.1f, Fatigue = 0.1f, Bladder = 0.1f,
+            Social = 0.65f
+        };
+        float meanBefore = (0.9f + 0.1f + 0.1f + 0.1f) / 4f;  // 0.3
+
+        var result = CoherenceDegradationSystem.ApplyToSnapshot(snapshot);
+
+        // Hunger should decrease toward mean; Thirst should increase toward mean
+        Assert.True(result.Hunger < 0.9f, "Hunger should compress downward toward mean");
+        Assert.True(result.Thirst > 0.1f, "Thirst should compress upward toward mean");
+        // Mean of compressed values should remain the same
+        float meanAfter = (result.Hunger + result.Thirst + result.Fatigue + result.Bladder) / 4f;
+        Assert.Equal(meanBefore, meanAfter, precision: 4);
+    }
+
+    // ── Full isolation: drives equal mean ────────────────────────────────────
+
+    [Fact]
+    public void WhenSocialAtMaximum_AllDrivesEqualMean()
+    {
+        var snapshot = new BodyState
+        {
+            Hunger = 0.9f, Thirst = 0.1f, Fatigue = 0.5f, Bladder = 0.3f,
+            Social = 1.0f  // maximum isolation → isolationFactor = 1.0
+        };
+        float expectedMean = (0.9f + 0.1f + 0.5f + 0.3f) / 4f;  // 0.45
+
+        var result = CoherenceDegradationSystem.ApplyToSnapshot(snapshot);
+
+        Assert.Equal(expectedMean, result.Hunger,  precision: 4);
+        Assert.Equal(expectedMean, result.Thirst,  precision: 4);
+        Assert.Equal(expectedMean, result.Fatigue, precision: 4);
+        Assert.Equal(expectedMean, result.Bladder, precision: 4);
+    }
+
+    // ── Social, Mood, SuppressionBudget are not modified ─────────────────────
+
+    [Fact]
+    public void ApplyToSnapshot_DoesNotModifySocialMoodOrBudget()
+    {
+        var snapshot = new BodyState
+        {
+            Hunger = 0.9f, Thirst = 0.1f, Fatigue = 0.5f, Bladder = 0.3f,
+            Social = 0.9f,
+            Mood = 0.6f,
+            SuppressionBudget = 0.75f
+        };
+
+        var result = CoherenceDegradationSystem.ApplyToSnapshot(snapshot);
+
+        Assert.Equal(0.9f,  result.Social,            precision: 4);
+        Assert.Equal(0.6f,  result.Mood,              precision: 4);
+        Assert.Equal(0.75f, result.SuppressionBudget, precision: 4);
+    }
+
+    // ── BehavioralCoherence: ranges correctly ─────────────────────────────────
+
+    [Fact]
+    public void BehavioralCoherence_IsOneWhenSocialBelowThreshold()
+    {
+        Assert.Equal(1.0f, CoherenceDegradationSystem.BehavioralCoherence(0.0f),  precision: 4);
+        Assert.Equal(1.0f, CoherenceDegradationSystem.BehavioralCoherence(0.30f), precision: 4);
+    }
+
+    [Fact]
+    public void BehavioralCoherence_IsZeroAtMaxIsolation()
+    {
+        Assert.Equal(0.0f, CoherenceDegradationSystem.BehavioralCoherence(1.0f), precision: 4);
+    }
+
+    [Fact]
+    public void BehavioralCoherence_DecreasesMonotonicallyWithIsolation()
+    {
+        float prev = CoherenceDegradationSystem.BehavioralCoherence(0.3f);
+        foreach (var social in new[] { 0.4f, 0.5f, 0.65f, 0.8f, 1.0f })
+        {
+            float current = CoherenceDegradationSystem.BehavioralCoherence(social);
+            Assert.True(current <= prev, $"Coherence should decrease as Social increases (at {social})");
+            prev = current;
+        }
+    }
+}

--- a/SquishySim.Tests/Mind/CognitiveDriftSystemTests.cs
+++ b/SquishySim.Tests/Mind/CognitiveDriftSystemTests.cs
@@ -1,0 +1,126 @@
+using SquishySim.Body;
+using SquishySim.Domain;
+using SquishySim.Mind;
+
+namespace SquishySim.Tests.Mind;
+
+public class CognitiveDriftSystemTests
+{
+    private static Agent AgentWith(float social, float drift = 0.0f) => new Agent
+    {
+        Id = "test", Name = "Test",
+        Drives = { Social = social },
+        PersonaDriftFactor = drift
+    };
+
+    // ── Accumulation: drift grows when isolated ───────────────────────────────
+
+    [Fact]
+    public void WhenSocialAboveIsolationThreshold_DriftAccumulates()
+    {
+        var agent = AgentWith(social: 0.6f, drift: 0.0f);  // 0.6 > 0.50 threshold
+
+        CognitiveDriftSystem.Tick(agent);
+
+        Assert.True(agent.PersonaDriftFactor > 0.0f, "Drift should accumulate when isolated");
+    }
+
+    [Fact]
+    public void WhenSocialAtIsolationThreshold_DriftDoesNotAccumulate()
+    {
+        var agent = AgentWith(social: 0.50f, drift: 0.2f);  // exactly at threshold
+
+        CognitiveDriftSystem.Tick(agent);
+
+        Assert.Equal(0.2f, agent.PersonaDriftFactor, precision: 4);
+    }
+
+    // ── Recovery: drift clears when social ───────────────────────────────────
+
+    [Fact]
+    public void WhenSocialBelowRecoveryThreshold_DriftDecreases()
+    {
+        var agent = AgentWith(social: 0.2f, drift: 0.5f);  // 0.2 < 0.30 recovery threshold
+
+        CognitiveDriftSystem.Tick(agent);
+
+        Assert.True(agent.PersonaDriftFactor < 0.5f, "Drift should decrease when socially active");
+    }
+
+    [Fact]
+    public void WhenSocialAtRecoveryThreshold_DriftDoesNotRecover()
+    {
+        var agent = AgentWith(social: 0.30f, drift: 0.3f);  // exactly at recovery threshold
+
+        CognitiveDriftSystem.Tick(agent);
+
+        Assert.Equal(0.3f, agent.PersonaDriftFactor, precision: 4);
+    }
+
+    // ── Plateau: between thresholds, drift is unchanged ──────────────────────
+
+    [Fact]
+    public void WhenSocialBetweenThresholds_DriftIsUnchanged()
+    {
+        var agent = AgentWith(social: 0.40f, drift: 0.35f);  // 0.30 < 0.40 < 0.50
+
+        CognitiveDriftSystem.Tick(agent);
+
+        Assert.Equal(0.35f, agent.PersonaDriftFactor, precision: 4);
+    }
+
+    // ── Bounds: drift stays within [0, 1] ────────────────────────────────────
+
+    [Fact]
+    public void DriftFactor_NeverExceedsOneUnderSustainedIsolation()
+    {
+        var agent = AgentWith(social: 1.0f, drift: 0.999f);
+
+        for (int i = 0; i < 10; i++)
+            CognitiveDriftSystem.Tick(agent);
+
+        Assert.True(agent.PersonaDriftFactor <= 1.0f, "Drift should be capped at 1.0");
+    }
+
+    [Fact]
+    public void DriftFactor_NeverGoesBelowZeroUnderSustainedRecovery()
+    {
+        var agent = AgentWith(social: 0.0f, drift: 0.001f);
+
+        for (int i = 0; i < 10; i++)
+            CognitiveDriftSystem.Tick(agent);
+
+        Assert.True(agent.PersonaDriftFactor >= 0.0f, "Drift should be floored at 0.0");
+    }
+
+    // ── Persona string: drift modifies the returned persona ──────────────────
+
+    [Fact]
+    public void BuildDriftedPersona_ReturnsBasePersona_WhenDriftBelowThreshold()
+    {
+        var base_ = "You tend to hold your needs.";
+        Assert.Equal(base_, CognitiveDriftSystem.BuildDriftedPersona(base_, 0.05f));
+    }
+
+    [Fact]
+    public void BuildDriftedPersona_AppendsLightDriftText_WhenDriftModerate()
+    {
+        var base_ = "You tend to hold your needs.";
+        var result = CognitiveDriftSystem.BuildDriftedPersona(base_, 0.25f);
+
+        Assert.StartsWith(base_, result);
+        Assert.True(result!.Length > base_.Length, "Drifted persona should be longer than base");
+    }
+
+    [Fact]
+    public void BuildDriftedPersona_ReturnsNull_WhenBasePersonaIsNull()
+    {
+        Assert.Null(CognitiveDriftSystem.BuildDriftedPersona(null, 0.9f));
+    }
+
+    [Fact]
+    public void BuildDriftedPersona_ReturnsEmpty_WhenBasePersonaIsEmpty()
+    {
+        Assert.Equal("", CognitiveDriftSystem.BuildDriftedPersona("", 0.9f));
+    }
+}

--- a/SquishySim.Tests/Services/SimulationServiceSpatialTests.cs
+++ b/SquishySim.Tests/Services/SimulationServiceSpatialTests.cs
@@ -17,14 +17,15 @@ public class SimulationServiceSpatialTests
         var alice = sim.GetAgent("alice")!;
 
         // Place alice far from food; set hunger high so decision maker picks eat_food.
-        // Social=0.70 (above SocialTriggerThreshold=0.65) disables Phase 3 context modifier
-        // so hunger threshold stays at 0.70 and 0.80 reliably triggers eat_food.
+        // Social=0.0 + SuppressionBudget=0.0 (snapped): no context modifier AND no coherence
+        // compression (Social below onset threshold 0.3). Hunger=0.80 > raw threshold 0.70 → eat_food.
         alice.Position  = (0f, 0f);
-        alice.Drives.Hunger  = 0.80f;   // above 0.70f threshold → eat_food
+        alice.Drives.Hunger  = 0.80f;   // above 0.70f raw threshold → eat_food
         alice.Drives.Thirst  = 0.10f;
         alice.Drives.Fatigue = 0.10f;
         alice.Drives.Bladder = 0.10f;
-        alice.Drives.Social  = 0.70f;   // above SocialTriggerThreshold → context modifier inactive
+        alice.Drives.Social  = 0.0f;    // below coherence onset threshold → no drive compression
+        alice.Drives.SuppressionBudget = 0.0f;  // snapped → no context modifier
 
         sim.Step();
 
@@ -46,16 +47,17 @@ public class SimulationServiceSpatialTests
         var alice = sim.GetAgent("alice")!;
 
         // Place alice within interact radius of food station (5,5).
-        // Social=0.70 disables Phase 3 context modifier so hunger threshold stays at 0.70
-        // and eat_food is chosen; CurrentAction must be "eat_food" for ApplyArrivalEffects to work.
+        // Social=0.0 + SuppressionBudget=0.0 (snapped): no context modifier AND no coherence
+        // compression (Social below onset threshold 0.3). Hunger=0.80 > raw threshold 0.70 → eat_food.
         alice.Position    = (5f, 5f - ResourceInteractRadius + 0.1f);  // just inside radius
         alice.NavState    = NavigationState.Committed;
         alice.Destination = (5f, 5f);
-        alice.Drives.Hunger  = 0.80f;   // hunger high → eat_food chosen
+        alice.Drives.Hunger  = 0.80f;   // above 0.70f raw threshold → eat_food chosen
         alice.Drives.Thirst  = 0.10f;
         alice.Drives.Fatigue = 0.10f;
         alice.Drives.Bladder = 0.10f;
-        alice.Drives.Social  = 0.70f;   // above SocialTriggerThreshold → context modifier inactive
+        alice.Drives.Social  = 0.0f;    // below coherence onset threshold → no drive compression
+        alice.Drives.SuppressionBudget = 0.0f;  // snapped → no context modifier
 
         var hungerBefore = alice.Drives.Hunger;
 
@@ -76,16 +78,17 @@ public class SimulationServiceSpatialTests
         var alice = sim.GetAgent("alice")!;
 
         // Alice is currently navigating to water (thirst was high, bladder was low).
-        // Social=0.70 disables Phase 3 context modifier so bladder threshold stays at 0.80
-        // and 0.85 reliably triggers use_toilet preemption (with modifier active, threshold=1.0).
+        // Social=0.0 + SuppressionBudget=0.0 (snapped): no context modifier AND no coherence
+        // compression. Bladder=0.85 > raw threshold 0.80 → use_toilet preempts water navigation.
         alice.Position    = (0f, 0f);
         alice.NavState    = NavigationState.Committed;
         alice.Destination = (15f, 5f);   // water station
         alice.Drives.Thirst  = 0.75f;
-        alice.Drives.Bladder = 0.85f;    // bladder above threshold → use_toilet takes priority
+        alice.Drives.Bladder = 0.85f;    // above 0.80 raw threshold → use_toilet takes priority
         alice.Drives.Hunger  = 0.10f;
         alice.Drives.Fatigue = 0.10f;
-        alice.Drives.Social  = 0.70f;    // above SocialTriggerThreshold → context modifier inactive
+        alice.Drives.Social  = 0.0f;    // below coherence onset threshold → no drive compression
+        alice.Drives.SuppressionBudget = 0.0f;  // snapped → no context modifier
 
         sim.Step();
 

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -274,6 +274,19 @@ function initMapStatic() {
     });
 }
 
+// Blend a hex color toward #888888 (gray) by factor [0,1].
+// factor=0 → original color; factor=1 → full gray.
+function blendTowardGray(hex, factor) {
+    const r = parseInt(hex.slice(1, 3), 16);
+    const g = parseInt(hex.slice(3, 5), 16);
+    const b = parseInt(hex.slice(5, 7), 16);
+    const gray = 136;  // 0x88
+    const br = Math.round(r + (gray - r) * factor);
+    const bg = Math.round(g + (gray - g) * factor);
+    const bb = Math.round(b + (gray - b) * factor);
+    return `#${br.toString(16).padStart(2, '0')}${bg.toString(16).padStart(2, '0')}${bb.toString(16).padStart(2, '0')}`;
+}
+
 // Redrawn each poll: nav state lines (first) then agent circles (on top)
 function renderSimMap(agents) {
     const mapDynamic = document.getElementById('map-dynamic');
@@ -308,7 +321,11 @@ function renderSimMap(agents) {
     // Draw agent circles on top of lines
     agents.forEach(a => {
         if (!a.position) return;
-        const color = AGENT_COLORS[a.id] ?? '#888888';
+        const baseColor = AGENT_COLORS[a.id] ?? '#888888';
+        // Desaturate toward gray proportional to isolation (behavioral coherence degradation).
+        // Visually distinct from snap (red ring): isolation is chronic/gradual, snap is acute.
+        const isolationFactor = a.behavioralCoherence != null ? Math.max(0, 1.0 - a.behavioralCoherence) : 0;
+        const color = isolationFactor > 0 ? blendTowardGray(baseColor, isolationFactor) : baseColor;
         const isSelected = a.id === selectedAgentId;
         const r = isSelected ? '0.8' : '0.65';
 
@@ -319,7 +336,11 @@ function renderSimMap(agents) {
         if (a.drives) {
             const d = a.drives;
             const budgetLabel = d.suppressionBudget <= 0.25 ? 'LOW' : d.suppressionBudget <= 0.50 ? 'MED' : 'OK';
-            tip = `${a.name}${a.isSnapped ? ' [SNAPPED]' : ''}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}  budget: ${budgetLabel}`;
+            const driftLabel = a.personaDriftFactor != null ? a.personaDriftFactor.toFixed(2) : '?';
+            const coherenceLabel = a.behavioralCoherence != null ? a.behavioralCoherence.toFixed(2) : '?';
+            const snappedTag = a.isSnapped ? ' [SNAPPED]' : '';
+            const driftTag = a.personaDriftFactor > 0.4 ? ' [DRIFTED]' : '';
+            tip = `${a.name}${snappedTag}${driftTag}\nhunger: ${d.hunger.toFixed(2)}  thirst: ${d.thirst.toFixed(2)}  fatigue: ${d.fatigue.toFixed(2)}\nbladder: ${d.bladder.toFixed(2)}  social: ${d.social.toFixed(2)}  mood: ${d.mood.toFixed(2)}\nnav: ${a.navState ?? ''}  budget: ${budgetLabel}\ncoherence: ${coherenceLabel}  drift: ${driftLabel}`;
             circle.appendChild(svgTitle(tip));
         }
         mapDynamic.appendChild(circle);


### PR DESCRIPTION
## Summary

- **Layer 1 (behavioral):** `CoherenceDegradationSystem` compresses physical drive urgencies toward their mean proportional to `Social` isolation level. Applied to decision-maker snapshots — both rule-based and Ollama DMs see compressed urgencies under isolation. Onset at Social=0.3; full compression at Social=1.0 (all drives equal mean). This is the leading observable layer.
- **Layer 2 (cognitive):** `CognitiveDriftSystem` accumulates `PersonaDriftFactor` on `Agent` under sustained isolation (Social > 0.5). Slower time constant than behavioral — behavioral incoherence is the leading observable, cognitive drift follows. `PersonaDriftFactor` modifies the persona string passed to LLM prompt builders.
- **Observable signal:** SVG map desaturates agent color toward gray proportional to isolation factor (distinct from snap's red ring — chronic/gradual vs acute/event). REST API exposes `personaDriftFactor` and `behavioralCoherence` on all agent endpoints.
- **Rate constants:** Behavioral coherence responds immediately to `Social` level. Cognitive drift accumulates at 0.005/tick (~200 ticks isolated → full drift), recovers at 0.008/tick (~125 ticks social → clear). Tunable empirically.

## Design decisions captured

- Behavioral coherence uses `state.Social` directly as lerp parameter (not accumulated) — responds immediately, is the faster layer
- Cognitive drift is mind-layer state (on `Agent`, not `BodyState`), distinct time constant
- Neither layer is tied to `SuppressionBudget` snap state — distinct failure modes with different recovery conditions
- Visual tell: desaturation (not ring) — Gus's call. Snap owns the ring vocabulary; isolation is chronic, not acute

## Files changed

- `Body/CoherenceDegradationSystem.cs` — new static class, compression logic + `BehavioralCoherence()` helper
- `Mind/CognitiveDriftSystem.cs` — new static class, drift accumulation + `BuildDriftedPersona()`
- `Domain/Agent.cs` — `PersonaDriftFactor` field
- `Services/SimulationService.cs` — Phase 2b drift tick, snapshot applies coherence degradation + drifted persona
- `Controllers/AgentsController.cs` — `PersonaDriftFactor` and `BehavioralCoherence` in `AgentDto`
- `wwwroot/app.js` — desaturation + tooltip shows coherence/drift values

## Tests

108/108 passing. New tests:
- `CoherenceDegradationSystemTests` (8 tests) — compression math, Social/Mood/Budget left unchanged, BehavioralCoherence monotonicity
- `CognitiveDriftSystemTests` (10 tests) — accumulation/recovery/plateau, bounds, persona string output

**3 existing spatial tests updated** (`SimulationServiceSpatialTests` AC7/AC8/AC9): these used `Social=0.70` to disable the context modifier, which now also triggers coherence degradation. Updated to `Social=0.0 + SuppressionBudget=0.0` (snapped state — no modifier AND no compression). Spatial mechanics being tested are unchanged.

## How it was tested

- All 108 tests pass
- Manually stepped the sim via `POST /sim/step` and polled `GET /agents` — verified `behavioralCoherence` decreases and `personaDriftFactor` accumulates as `social` rises
- Verified SVG agent circles desaturate toward gray as isolation increases, snap ring still visible on desaturated agent (red on gray reads clearly)

Fixes #24 (if created) — social isolation coherence mechanic

🤖 Generated with [Claude Code](https://claude.com/claude-code)